### PR TITLE
fix(game-reports): close gemma chat sessions

### DIFF
--- a/flutter_app/lib/micro_apps/game_reports/services/function_gemma_service.dart
+++ b/flutter_app/lib/micro_apps/game_reports/services/function_gemma_service.dart
@@ -161,6 +161,20 @@ class FunctionGemmaService {
     _isInitialized = false;
   }
 
+  /// Safely closes the current chat session to prevent memory/GPU leaks.
+  ///
+  /// This method:
+  /// - Captures the session reference locally before nulling to avoid race conditions
+  /// - Nulls [_chatSession] immediately to prevent concurrent access
+  /// - Silently catches and logs any close errors to avoid disrupting the caller
+  ///
+  /// Called automatically:
+  /// - Before creating a new session in [generateResponse]
+  /// - After completing or failing a response in [generateResponse] (via finally)
+  /// - In [dispose] for final cleanup
+  @visibleForTesting
+  Future<void> closeChatSession() => _closeChatSession();
+
   Future<void> _closeChatSession() async {
     final session = _chatSession;
     _chatSession = null;

--- a/flutter_app/lib/micro_apps/game_reports/services/function_gemma_service.dart
+++ b/flutter_app/lib/micro_apps/game_reports/services/function_gemma_service.dart
@@ -120,6 +120,8 @@ class FunctionGemmaService {
     }
 
     try {
+      await _closeChatSession();
+
       // Create a new chat session for each request
       _chatSession = await _model!.createChat(
         tools: tools ?? [],
@@ -145,14 +147,31 @@ class FunctionGemmaService {
     } catch (e) {
       debugPrint('Inference error: $e');
       return null;
+    } finally {
+      await _closeChatSession();
     }
   }
 
   /// Cleanup resources when the service is no longer needed.
   Future<void> dispose() async {
+    await _closeChatSession();
     await _model?.close();
     _chatSession = null;
     _model = null;
     _isInitialized = false;
+  }
+
+  Future<void> _closeChatSession() async {
+    final session = _chatSession;
+    _chatSession = null;
+    if (session == null) {
+      return;
+    }
+
+    try {
+      await session.session.close();
+    } catch (e) {
+      debugPrint('Failed to close chat session: $e');
+    }
   }
 }

--- a/flutter_app/test/micro_apps/game_reports/services/function_gemma_service_test.dart
+++ b/flutter_app/test/micro_apps/game_reports/services/function_gemma_service_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tackle4loss/micro_apps/game_reports/services/function_gemma_service.dart';
+
+void main() {
+  group('FunctionGemmaService', () {
+    group('session cleanup', () {
+      test('closeChatSession is idempotent and safe to call multiple times',
+          () async {
+        final service = FunctionGemmaService();
+
+        // Should not throw when called with no active session
+        await expectLater(
+          service.closeChatSession(),
+          completes,
+        );
+
+        // Should be safe to call multiple times
+        await expectLater(
+          service.closeChatSession(),
+          completes,
+        );
+      });
+
+      test('dispose cleans up sessions and resets state', () async {
+        final service = FunctionGemmaService();
+
+        // dispose should complete without error even if no model loaded
+        await expectLater(
+          service.dispose(),
+          completes,
+        );
+
+        // After dispose, model should not be ready
+        expect(service.isModelReady, isFalse);
+      });
+    });
+
+    group('model state', () {
+      test('isModelReady is false initially', () {
+        final service = FunctionGemmaService();
+        expect(service.isModelReady, isFalse);
+      });
+
+      test('generateResponse returns null when model not ready', () async {
+        final service = FunctionGemmaService();
+
+        final result = await service.generateResponse('test prompt');
+
+        expect(result, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #30.

## Summary
- close previous FunctionGemma chat sessions before/after each request
- add safe session cleanup helper and reuse in dispose

## Testing
- Not run (local)