### PR TITLE
Fix GameReportScreen setState after dispose

### DIFF
--- a/flutter_app/lib/micro_apps/game_reports/views/game_report_screen.dart
+++ b/flutter_app/lib/micro_apps/game_reports/views/game_report_screen.dart
@@ -50,12 +50,14 @@ class _GameReportScreenState extends State<GameReportScreen> {
   Future<void> _loadCompletedGames() async {
     try {
       final allGames = await _standingsService.fetchGames();
+      if (!mounted) return;
       setState(() {
         _completedGames = allGames.where((g) => g.isPlayed).toList()
           ..sort((a, b) => b.gameday.compareTo(a.gameday));
         _isLoadingGames = false;
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() => _isLoadingGames = false);
     }
   }


### PR DESCRIPTION
## Summary\n- guard _loadCompletedGames setState calls with mounted checks\n- prevent setState after dispose when exiting fast\n\n## Testing\n- not run (not requested)