### PR TITLE
Fix #46: guard news feed precache

### DIFF
--- a/flutter_app/lib/core/os_shell/widgets/news_feed/news_feed_widget.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/news_feed_widget.dart
@@ -24,6 +24,7 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
   String? _currentLanguageCode;
   ScrollController? _scrollController;
   DateTime? _lastLoadMoreAt;
+  int _lastPrecachingIndex = -1;
 
   static const double _loadMoreThreshold = 320.0;
   static const Duration _loadMoreThrottle = Duration(milliseconds: 600);
@@ -32,6 +33,7 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
     _controller = NewsFeedController(
       languageCode: settings.locale.languageCode,
     );
+    _lastPrecachingIndex = -1;
     _controller.loadInitial();
   }
 
@@ -94,8 +96,13 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
   /// Pre-cache images for upcoming feed items to improve perceived loading speed
   void _precacheUpcomingImages(BuildContext context, int currentIndex) {
     const lookAhead = 3;
+    if (currentIndex + lookAhead <= _lastPrecachingIndex) return;
+    var maxPrecachingIndex = _lastPrecachingIndex;
     for (int i = 1; i <= lookAhead; i++) {
       final nextIndex = currentIndex + i;
+      if (nextIndex <= _lastPrecachingIndex) {
+        continue;
+      }
       if (nextIndex < _controller.items.length) {
         final item = _controller.items[nextIndex];
         if (item is NewsFeedItem && item.imageUrl != null) {
@@ -107,9 +114,13 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
             ),
             context,
           );
+          if (nextIndex > maxPrecachingIndex) {
+            maxPrecachingIndex = nextIndex;
+          }
         }
       }
     }
+    _lastPrecachingIndex = maxPrecachingIndex;
   }
 
   @override


### PR DESCRIPTION
## Summary
- add a precache guard to avoid repeated work during rebuilds
- track the last precached index and only precache new items
- reset precache tracking on controller init

## Testing
- Analyzing news_feed_widget.dart...

  error - news_feed_widget.dart:1:8 - Target of URI doesn't exist: 'package:flutter/material.dart'. Try creating the file referenced by the URI, or try using a URI for a file that does exist. - uri_does_not_exist
  error - news_feed_widget.dart:2:8 - Target of URI doesn't exist: 'package:cached_network_image/cached_network_image.dart'. Try creating the file referenced by the URI, or try using a URI for a file that does exist. - uri_does_not_exist
  error - news_feed_widget.dart:3:8 - Target of URI doesn't exist: 'package:provider/provider.dart'. Try creating the file referenced by the URI, or try using a URI for a file that does exist. - uri_does_not_exist
  error - news_feed_widget.dart:14:30 - Classes can only extend other classes. Try specifying a different superclass, or removing the extends clause. - extends_non_class
  error - news_feed_widget.dart:15:31 - No associated named super constructor parameter. Try changing the name to the name of an existing named super constructor parameter, or creating such named parameter. - super_formal_parameter_without_associated_named
  error - news_feed_widget.dart:18:3 - Undefined class 'State'. Try changing the name to the name of an existing class, or creating a class with the name 'State'. - undefined_class
  error - news_feed_widget.dart:21:36 - Classes can only extend other classes. Try specifying a different superclass, or removing the extends clause. - extends_non_class
  error - news_feed_widget.dart:25:3 - Undefined class 'ScrollController'. Try changing the name to the name of an existing class, or creating a class with the name 'ScrollController'. - undefined_class
  error - news_feed_widget.dart:40:32 - Undefined class 'ScrollController'. Try changing the name to the name of an existing class, or creating a class with the name 'ScrollController'. - undefined_class
  error - news_feed_widget.dart:70:11 - The method 'didChangeDependencies' isn't defined in a superclass of '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'didChangeDependencies' in a superclass. - undefined_super_member
  error - news_feed_widget.dart:71:22 - Undefined name 'Provider'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:71:51 - Undefined name 'context'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:73:29 - Undefined name 'PrimaryScrollController'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:73:61 - Undefined name 'context'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:93:11 - The method 'dispose' isn't defined in a superclass of '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'dispose' in a superclass. - undefined_super_member
  error - news_feed_widget.dart:97:32 - Undefined class 'BuildContext'. Try changing the name to the name of an existing class, or creating a class with the name 'BuildContext'. - undefined_class
  error - news_feed_widget.dart:109:11 - The method 'precacheImage' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'precacheImage'. - undefined_method
  error - news_feed_widget.dart:110:13 - The method 'CachedNetworkImageProvider' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'CachedNetworkImageProvider'. - undefined_method
  error - news_feed_widget.dart:127:3 - Undefined class 'Widget'. Try changing the name to the name of an existing class, or creating a class with the name 'Widget'. - undefined_class
  error - news_feed_widget.dart:127:16 - Undefined class 'BuildContext'. Try changing the name to the name of an existing class, or creating a class with the name 'BuildContext'. - undefined_class
  error - news_feed_widget.dart:128:22 - Undefined name 'Provider'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:131:12 - The method 'ListenableBuilder' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'ListenableBuilder'. - undefined_method
  error - news_feed_widget.dart:135:18 - The method 'SliverToBoxAdapter' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SliverToBoxAdapter'. - undefined_method
  error - news_feed_widget.dart:136:20 - The method 'Padding' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'Padding'. - undefined_method
  error - news_feed_widget.dart:137:30 - Undefined name 'EdgeInsets'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:138:22 - The method 'Center' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'Center'. - undefined_method
  error - news_feed_widget.dart:139:24 - The method 'Column' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'Column'. - undefined_method
  error - news_feed_widget.dart:141:21 - The method 'Icon' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'Icon'. - undefined_method
  error - news_feed_widget.dart:142:23 - Undefined name 'Icons'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:144:30 - Undefined name 'Colors'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:146:27 - The name 'SizedBox' isn't a class. Try correcting the name to match an existing class. - creation_with_non_type
  error - news_feed_widget.dart:147:21 - The method 'Text' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'Text'. - undefined_method
  error - news_feed_widget.dart:149:30 - The method 'TextStyle' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'TextStyle'. - undefined_method
  error - news_feed_widget.dart:149:47 - Undefined name 'Colors'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:151:27 - The name 'SizedBox' isn't a class. Try correcting the name to match an existing class. - creation_with_non_type
  error - news_feed_widget.dart:152:21 - The method 'TextButton' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'TextButton'. - undefined_method
  error - news_feed_widget.dart:154:36 - The name 'Text' isn't a class. Try correcting the name to match an existing class. - creation_with_non_type
  error - news_feed_widget.dart:164:18 - The method 'SliverList' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SliverList'. - undefined_method
  error - news_feed_widget.dart:165:23 - The method 'SliverChildBuilderDelegate' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SliverChildBuilderDelegate'. - undefined_method
  error - news_feed_widget.dart:172:16 - The method 'SliverMainAxisGroup' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SliverMainAxisGroup'. - undefined_method
  error - news_feed_widget.dart:175:13 - The method 'SliverToBoxAdapter' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SliverToBoxAdapter'. - undefined_method
  error - news_feed_widget.dart:176:22 - The method 'SizedBox' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SizedBox'. - undefined_method
  error - news_feed_widget.dart:179:23 - The method 'Center' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'Center'. - undefined_method
  error - news_feed_widget.dart:180:32 - The method 'Opacity' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'Opacity'. - undefined_method
  error - news_feed_widget.dart:182:34 - Undefined name 'Image'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:186:34 - Undefined name 'BoxFit'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
  error - news_feed_widget.dart:187:62 - The name 'SizedBox' isn't a class. Try correcting the name to match an existing class. - creation_with_non_type
  error - news_feed_widget.dart:191:29 - The name 'SizedBox' isn't a class. Try correcting the name to match an existing class. - creation_with_non_type
  error - news_feed_widget.dart:196:13 - The method 'SliverList' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SliverList'. - undefined_method
  error - news_feed_widget.dart:197:25 - The method 'SliverChildBuilderDelegate' isn't defined for the type '_NewsFeedWidgetState'. Try correcting the name to the name of an existing method, or defining a method named 'SliverChildBuilderDelegate'. - undefined_method
  error - news_feed_widget.dart:204:34 - Undefined name 'SizedBox'. Try correcting the name to one that is defined, or defining the name. - undefined_identifier
warning - news_feed_widget.dart:18:25 - The method doesn't override an inherited method. Try updating this class to match the superclass, or removing the override annotation. - override_on_non_overriding_member
warning - news_feed_widget.dart:69:8 - The method doesn't override an inherited method. Try updating this class to match the superclass, or removing the override annotation. - override_on_non_overriding_member
warning - news_feed_widget.dart:90:8 - The method doesn't override an inherited method. Try updating this class to match the superclass, or removing the override annotation. - override_on_non_overriding_member
warning - news_feed_widget.dart:127:10 - The method doesn't override an inherited method. Try updating this class to match the superclass, or removing the override annotation. - override_on_non_overriding_member

55 issues found.