### PR TITLE
Fix #24: filter breaking news realtime by language

### DIFF
--- a/web/components/BreakingNewsList.tsx
+++ b/web/components/BreakingNewsList.tsx
@@ -33,16 +33,30 @@ export default function BreakingNewsList({ languageCode }: BreakingNewsListProps
 
         // Realtime Subscription
         const channel = supabase
-            .channel('breaking-news-changes')
+            .channel(`breaking-news-changes-${languageCode}`)
             .on(
                 'postgres_changes',
                 {
-                    event: '*',
+                    event: 'INSERT',
                     schema: 'content',
-                    table: 'news_updates'
+                    table: 'news_updates',
+                    filter: `language_code=eq.${languageCode}`
                 },
                 () => {
-                    console.log('Breaking news changed, refreshing...');
+                    console.log('Breaking news inserted, refreshing...');
+                    fetchBreakingNews();
+                }
+            )
+            .on(
+                'postgres_changes',
+                {
+                    event: 'UPDATE',
+                    schema: 'content',
+                    table: 'news_updates',
+                    filter: `language_code=eq.${languageCode}`
+                },
+                () => {
+                    console.log('Breaking news updated, refreshing...');
                     fetchBreakingNews();
                 }
             )

--- a/web/hooks/useBreakingNews.ts
+++ b/web/hooks/useBreakingNews.ts
@@ -23,10 +23,15 @@ export function useBreakingNews(languageCode: string) {
         fetchNews();
 
         const channel = supabase
-            .channel('breaking-news-system')
+            .channel(`breaking-news-system-${languageCode}`)
             .on(
                 'postgres_changes',
-                { event: 'INSERT', schema: 'content', table: 'news_updates' },
+                {
+                    event: 'INSERT',
+                    schema: 'content',
+                    table: 'news_updates',
+                    filter: `language_code=eq.${languageCode}`
+                },
                 (payload) => {
                     console.log('New breaking news!', payload);
                     fetchNews();


### PR DESCRIPTION
## Summary
- add language filter to breaking news realtime subscriptions
- restrict realtime events to INSERT/UPDATE instead of wildcard
- keep list refreshes scoped to the active language

## Testing
- not run (frontend change)