### PR TITLE
Fix #23: slim breaking news list payload

### DIFF
--- a/supabase/functions/get-breaking-news/index.ts
+++ b/supabase/functions/get-breaking-news/index.ts
@@ -8,11 +8,6 @@ const corsHeaders = {
     "Access-Control-Allow-Methods": "POST, OPTIONS",
 }
 
-interface PlayerData {
-    player_id?: string
-    [key: string]: unknown
-}
-
 // Utility to strip undefined values from an object
 function stripUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
     return Object.fromEntries(
@@ -44,7 +39,9 @@ serve(async (req) => {
         let query = supabaseClient
             .schema("content")
             .from("news_updates")
-            .select("*")
+            .select(
+                "id, headline, created_at, image_url, image_file, x_post, audio_file, tts_file"
+            )
             .gt("created_at", twentyFourHoursAgo)
             .order("created_at", { ascending: false })
 
@@ -55,32 +52,6 @@ serve(async (req) => {
         const { data, error } = await query
 
         if (error) throw error
-
-        // Extract all player IDs to fetch headshots in one go
-        const playerIds = new Set<string>()
-        data.forEach((item: Record<string, unknown>) => {
-            const players = item.players as PlayerData[] | undefined
-            if (players && Array.isArray(players)) {
-                players.forEach((p: PlayerData) => {
-                    if (p.player_id) playerIds.add(p.player_id)
-                })
-            }
-        })
-
-        // Fetch player details (headshot) from public.players
-        const playersMap = new Map<string, { headshot?: string }>()
-        if (playerIds.size > 0) {
-            const { data: playersData, error: playersError } = await supabaseClient
-                .from("players")
-                .select("player_id, headshot")
-                .in("player_id", Array.from(playerIds))
-
-            if (!playersError && playersData) {
-                playersData.forEach((p: { player_id: string; headshot?: string }) => 
-                    playersMap.set(p.player_id, p)
-                )
-            }
-        }
 
         const mappedData = data.map((item: Record<string, unknown>) => {
             const imageRaw =
@@ -103,16 +74,6 @@ serve(async (req) => {
                 (item.x_post as string | undefined) ??
                 (item.xPost as string | undefined)
 
-            // Enrich players with headshot_url
-            const playersArray = Array.isArray(item.players) ? item.players as PlayerData[] : []
-            const enrichedPlayers = playersArray.map((p: PlayerData) => {
-                const details = playersMap.get(p.player_id ?? "")
-                return {
-                    ...p,
-                    headshot_url: details?.headshot,
-                }
-            })
-
             // Build response object and strip undefined values
             return stripUndefined({
                 id: item.id as string,
@@ -125,17 +86,6 @@ serve(async (req) => {
                 imageUrl,
                 xPost,
                 audioFile,
-                subHeader:
-                    (item.sub_header as string | undefined) ??
-                    (item.subHeader as string | undefined),
-                introductionParagraph:
-                    (item.introduction_paragraph as string | undefined) ??
-                    (item.introductionParagraph as string | undefined) ??
-                    (item.introduction as string | undefined),
-                content: item.content as string | undefined,
-                teams: Array.isArray(item.teams) ? item.teams : undefined,
-                players: enrichedPlayers.length > 0 ? enrichedPlayers : undefined,
-                url: item.url as string | undefined,
             })
         })
 


### PR DESCRIPTION
## Summary
- limit get-breaking-news list query to lightweight fields only
- drop player enrichment and heavy content fields from list response
- keep response keys for list + notification UI

## Testing
- not run (edge function change)