### PR TITLE
Fix #46: guard news feed precache with URL-based dedup

### DIFF
--- a/flutter_app/lib/core/os_shell/widgets/news_feed/news_feed_widget.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/news_feed_widget.dart
@@ -153,7 +153,10 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
                     ),
                     const SizedBox(height: 16),
                     TextButton(
-                      onPressed: () => _controller.refresh(),
+                      onPressed: () {
+                        _precachedUrls.clear();
+                        _controller.refresh();
+                      },
                       child: const Text('Retry'),
                     ),
                   ],


### PR DESCRIPTION
## Summary

Prevents redundant `precacheImage` calls in the news feed by tracking already-precached URLs in a `Set<String>`.

Closes #46 — replaces the closed PR #49 which used fragile index-based tracking.

## What changed

**File:** `flutter_app/lib/core/os_shell/widgets/news_feed/news_feed_widget.dart`

- Added `_precachedUrls` (`Set<String>`) to `_NewsFeedWidgetState`
- `_precacheUpcomingImages` now skips URLs already in the set
- Set is cleared in `_initializeController` (covers language change & fresh init)

## Why URL-based instead of index-based (PR #49 approach)

The previous PR tracked `_lastPrecachingIndex`, but:
- Realtime inserts shift items at index 0, making a saved index stale
- `refresh()` resets the item list entirely, yet the old index would persist

A URL set is immune to list reordering and correctly handles all these scenarios.

## Testing

- `flutter analyze` — 0 issues
- All 14 existing news feed tests pass
- No breaking changes (additive only)