### PR TITLE
fix: properly cancel mediaItemStream subscription in RadioController

### DIFF
--- a/flutter_app/lib/micro_apps/radio/controllers/radio_controller.dart
+++ b/flutter_app/lib/micro_apps/radio/controllers/radio_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:audio_service/audio_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:tackle4loss_mobile/core/services/audio_player_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -42,6 +43,7 @@ class RadioController extends ChangeNotifier {
   Timer? _newsTimer;
   Set<String> _currentPlaylistIds = {};
   StreamSubscription<void>? _queueExhaustedSub;
+  StreamSubscription<MediaItem?>? _mediaItemSub;
   String _activeLanguageCode = 'en';
 
   RadioController({String? languageCode}) {
@@ -52,6 +54,7 @@ class RadioController extends ChangeNotifier {
   void dispose() {
     _newsTimer?.cancel();
     _queueExhaustedSub?.cancel();
+    _mediaItemSub?.cancel();
     super.dispose();
   }
 
@@ -60,7 +63,7 @@ class RadioController extends ChangeNotifier {
     await loadStations(languageCode);
 
     // Listen for playback changes to mark as played
-    _audioService.mediaItemStream.listen((mediaItem) {
+    _mediaItemSub = _audioService.mediaItemStream.listen((mediaItem) {
       if (mediaItem != null) {
         _markAsPlayed(mediaItem.id);
       }


### PR DESCRIPTION
## Summary
Fixes the memory leak in `RadioController` where the `mediaItemStream` subscription was never canceled.

## Changes
- Added `StreamSubscription<MediaItem?>? _mediaItemSub` field to store the subscription
- Store the subscription when calling `listen()` in `_initAndLoad()`
- Cancel the subscription in `dispose()` to prevent leaks
- Added `audio_service` import for the `MediaItem` type

## Testing
- All 6 existing RadioController tests pass
- No regression in functionality

Fixes #42