### PR TITLE
feat(flutter): home/detail V3 redesign + articles backend swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog — 2026-04-20
+
+## Summary
+
+Slimmed the Flutter app (`flutter_app/`) down to a focused MVP scope targeting App Store submission within 5 weeks. The session went from idea-discovery → product-architect → /plan → 8 implementation commits, leaving the app with a clean 4-item dock, mandatory onboarding, and all non-MVP features flag-off (code stays in repo, hidden at runtime).
+
+## MVP Visible Surface (locked)
+
+- **Home** — News feed
+- **Standings** — Full standings view (Game Center button in dock)
+- **Team Center** — Roster / Depth Chart / Injuries overlay (center team-logo button in dock)
+- **Settings** — Language + team override, app info
+
+## What Was Removed / Hidden
+
+| Removed from MVP | Disposition |
+|---|---|
+| History dock tab | Deleted from Dock; can be restored post-launch |
+| AppStrip (app grid) | Hidden at runtime; code intact |
+| RadioHomeWidget | Hidden at runtime; code intact |
+| Games Timeline (Team Center overlay) | Removed from overlay tab list |
+| MicroApps: `app_store`, `deep_dive`, `game_reports`, `player_wordle`, `radio` | Feature-flagged off in `AppRegistry`; not shown in any shell UI |
+| `flutter_gemma` / TensorFlow Lite dependency | Dropped from `pubspec.yaml`; `FunctionGemmaService` and `GameReportTools` stubbed |
+
+## Changes (8 commits on `feature/flutter-mvp-slim`)
+
+- **Phase 1** (`9e37e99`) — Strip boot graph: remove non-MVP MicroApp registrations from `AppRegistry`, disable `RadioController` provider, set feature flags off for flagged apps, trim `store_assets` from `pubspec.yaml`.
+- **Phase 2** (`46fd6d4`) — Drop Deep Dive dependency from `OSShellController.isPageReady` so the home screen is no longer gated on a flagged-off app.
+- **Phase 3** (`a20be93`) — Slim Dock to 4 items: remove History tab, rearrange Home / Standings / Team Center / Settings.
+- **Phase 4** (`408438f`) — Hide `AppStrip` and `RadioHomeWidget` from the home layout; stop calling `InstalledAppsService.init()` (no app grid = no install state needed).
+- **Phase 5** (`cda5aea`) — Drop Games Timeline tab from the Team Center overlay; Team Center now shows Roster / Depth / Injuries only.
+- **Phase 6** (`3e5379a`) — Forced first-launch onboarding: new `FirstLaunchFlow` widget, `SettingsService.onboardingComplete` flag, `_RootGate` in `main.dart`. Non-dismissible until team + language are chosen. Auto-detects DE for German locale, EN otherwise; manual override available in Settings.
+- **Phase 7** (`e3e5ac7`) — `dart format` pass across all MVP slim changes.
+- **Phase 8** (`5a187b7`) — Drop `flutter_gemma` from `pubspec.yaml` to unblock iOS device build (`TensorFlowLiteSelectTfOps` framework was missing). Stubbed `FunctionGemmaService` and `GameReportTools` so the game_reports MicroApp compiles cleanly while flag-off.
+
+## Files Modified (implementation — already committed)
+
+- `flutter_app/lib/core/app_registry.dart` — feature-flag off non-MVP MicroApps
+- `flutter_app/lib/core/os_shell/os_shell_controller.dart` — drop Deep Dive from isPageReady gate
+- `flutter_app/lib/core/os_shell/views/os_shell_home.dart` — hide AppStrip + RadioHomeWidget
+- `flutter_app/lib/core/os_shell/widgets/dock/dock.dart` — 4-item dock
+- `flutter_app/lib/core/services/settings_service.dart` — add `onboardingComplete` flag + language auto-detect
+- `flutter_app/lib/micro_apps/team_center/views/team_center_overlay.dart` — drop Games Timeline tab
+- `flutter_app/lib/main.dart` — `_RootGate` driving `FirstLaunchFlow`
+- `flutter_app/lib/core/os_shell/widgets/first_launch_flow.dart` — new onboarding widget
+- `flutter_app/lib/micro_apps/game_reports/services/function_gemma_service.dart` — stubbed
+- `flutter_app/lib/micro_apps/game_reports/services/game_report_tools.dart` — stubbed
+- `flutter_app/pubspec.yaml` — drop `flutter_gemma`; trim `store_assets`
+
+## Code Quality Notes
+
+- `flutter analyze --fatal-warnings`: 2 pre-existing `info` hints in `radio_controller.dart` and its test — not warnings, not regressions.
+- `flutter test`: **222 passing, 22 skipped**. Skipped tests cover AppStrip install/reorder logic intentionally deferred pending a future AppStrip return.
+- `dart format --set-exit-if-changed .`: 1 file re-formatted post-commit (`game_report_tools.dart` — a line-wrap in a string description). Needs to be included in the next commit.
+
+## Open Items / Carry-over
+
+- [ ] Stage and commit `flutter_app/lib/micro_apps/game_reports/services/game_report_tools.dart` (dart format line-wrap fix) + `CLAUDE.md` (git workflow rules section) — awaiting explicit user approval.
+- [ ] Push `feature/flutter-mvp-slim` (8 commits + pending) to remote — awaiting explicit user approval.
+- [ ] App Store assets: screenshots, app description, Privacy Policy URL needed before submission.
+- [ ] TestFlight distribution + first internal build — next milestone after branch is pushed.
+- [ ] Push notifications, accounts/auth, monetization — explicitly out of MVP scope; revisit post-launch.
+- [ ] 22 skipped tests (AppStrip install/reorder) — clean up or restore when AppStrip returns post-MVP.
+- [ ] Plan file at `/Users/tobiaslatta/.claude/plans/snoopy-beaming-swing.md` covers full phase breakdown.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Layout
+
+This is a dual-stack monorepo:
+
+- `flutter_app/` — **Source of truth.** The production Flutter app (Tackle4Loss OS).
+- `web/` — A parallel React/Vite implementation. The README marks it as legacy/WIP, but the current branch (`Coder/parity-engine-foundation`) is actively rebuilding the web shell to reach parity with Flutter via shared design tokens.
+- `supabase/` — Edge functions backing both clients (`get-team-roster`, `get-team-injuries`, `get-team-depth-chart`, `get-daily-player`, `get-news-feed`, `get-team-article-detail`, etc.).
+- `flutter_app/lib/design_tokens.dart` is **generated** from `web/design-tokens.ts` by `web/export-tokens-to-dart.js` (`npm run export-tokens` in `web/`). Edit tokens in `web/`, not in Dart.
+
+## Common Commands
+
+### Flutter (`flutter_app/`)
+```bash
+cd flutter_app
+flutter pub get
+flutter run
+flutter analyze --fatal-warnings   # CI uses --fatal-warnings
+dart format --set-exit-if-changed . # CI fails on unformatted code
+flutter test
+flutter test test/path/to/file_test.dart   # single file
+flutter test --plain-name "test name"      # single test
+flutter test --coverage
+```
+A `.env` file with `SUPABASE_URL` and `SUPABASE_ANON_KEY` is required at `flutter_app/.env` (CI writes placeholders).
+
+### Web (`web/`)
+```bash
+cd web
+npm install
+npm run dev          # vite dev on :3000
+npm run build
+npm run export-tokens # regenerate flutter_app/lib/design_tokens.dart
+```
+Requires `web/.env` with `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
+
+### CI
+`.github/workflows/flutter.yml` runs only on changes under `flutter_app/**`. It runs format check, `flutter analyze --fatal-warnings`, and `flutter test --coverage`. There is currently no CI for `web/`.
+
+## Architecture: The OS Shell + MicroApps
+
+The Flutter app is structured as a **mini operating system**, not a traditional navigation app. Understanding this is essential before editing anything in `lib/`.
+
+- `lib/core/os_shell/` hosts the shell UI: app strip, dock, news feed, team center overlay.
+- `lib/core/services/` are the system services that the shell depends on:
+  - `AppRegistry` (`lib/core/app_registry.dart`) — central catalog of every available MicroApp.
+  - `InstalledAppsService` — tracks which apps the user has "installed" on their grid.
+  - `NavigationService` — routes between the shell and individual MicroApps (do not bypass it with raw `Navigator` pushes for app-level navigation).
+  - `FeatureFlagService` — gates MicroApp visibility; new apps default to off until production-audited.
+- `lib/micro_apps/<id>/` — each MicroApp is a self-contained module following **strict MVC** (`models/`, `views/`, `controllers/` with `ChangeNotifier`). MicroApps must register themselves in `AppRegistry` to appear in the shell.
+- `lib/core/adk/` — the App Development Kit. `ADK_GUIDE.md` defines the mandatory 8-step lifecycle for adding a MicroApp; follow it exactly. Reference implementations: `RadioScreen`, `StandingsScreen`.
+
+The web side mirrors this concept (`web/components/OSAppGrid.tsx`, `AppStrip.tsx`, `FloatingNavBar.tsx`, `web/components/apps/`).
+
+### MVP Slim State (as of 2026-04-20, branch `feature/flutter-mvp-slim`)
+
+The app has been slimmed to an App Store MVP. Key runtime differences from the full architecture above:
+
+- **Dock is 4 items only:** Home (news feed), Standings, Team Center (center logo button), Settings. History tab is dropped.
+- **AppStrip and RadioHomeWidget are hidden** from the home screen layout. `InstalledAppsService.init()` is not called. The code remains in the repo.
+- **Mandatory first-launch onboarding:** `_RootGate` in `main.dart` shows `FirstLaunchFlow` (team + language picker) until `SettingsService.onboardingComplete` is true. Non-dismissible.
+- **Localization:** auto-detects German locale → DE, otherwise EN; user can override in Settings.
+- **Flag-off MicroApps (code in repo, hidden at runtime):** `app_store`, `deep_dive`, `game_reports`, `player_wordle`, `radio`.
+- **Games Timeline removed** from Team Center overlay. Team Center shows: Roster / Depth / Injuries.
+- **`flutter_gemma` / TensorFlow Lite dropped** from `pubspec.yaml` (no MVP consumer; was blocking iOS device builds). `FunctionGemmaService` and `GameReportTools` are stubbed.
+
+Full phase-by-phase breakdown: `/Users/tobiaslatta/.claude/plans/snoopy-beaming-swing.md`
+
+## Git workflow rules
+
+- **Never commit without the user's explicit approval.** Propose the change, show the diff or summarize what will be committed, and wait for a "yes, commit" from the user. Plan approval, task approval, and auto-mode are NOT approval to commit — they only authorize the code changes themselves. This applies even mid-plan and mid-phase: each commit needs its own green light.
+- **Never push without the user's explicit approval.** Same rule. Branch approval is not push approval.
+- **Never push to `main`.** Always work on a feature branch (e.g. `feature/xyz`, `issue_killer/xyz`). If a push fails, stop and investigate — never force-push without verifying the branch.
+
+## Non-Obvious Rules (from `agent.md`)
+
+- **Always** use `T4LScaffold` in default Standard Mode (`extendBodyBehindHeader: false`). It already handles header spacing.
+- **Never** use `SliverAppBar`, `NestedScrollView`, `extendBodyBehindHeader: true`, or manual top padding to "fix" spacing. If spacing looks wrong, simplify the layout (revert to plain `Column`/`ListView`) instead of adding compensating hacks.
+- If a core widget (e.g. `T4LHeroHeader`) misbehaves, refactor it into a standard widget — do not fight the framework.
+- Design tokens in `lib/design_tokens.dart` (`AppColors`, `AppTextStyles`, `AppSpacing` — 8pt grid) are the **only** allowed source for color/type/spacing in Flutter. Hard-coded values are forbidden and will fail review.
+
+## Adding a MicroApp (summary)
+
+1. Create `lib/micro_apps/<id>/{models,views,controllers}/`.
+2. Build the View on top of `T4LScaffold` and `design_tokens.dart`.
+3. Register in `AppRegistry`; gate via `FeatureFlagService`.
+4. Add unit tests (models/controllers) and widget tests (views); `flutter test` must be green.
+5. Add `lib/micro_apps/<id>/README.md` documenting the why/how.
+6. Open a PR titled `[PUBLISH] <App Name> (<App ID>)`.
+
+Full checklist in `flutter_app/lib/core/adk/ADK_GUIDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ flutter test test/path/to/file_test.dart   # single file
 flutter test --plain-name "test name"      # single test
 flutter test --coverage
 ```
-A `.env` file with `SUPABASE_URL` and `SUPABASE_ANON_KEY` is required at `flutter_app/.env` (CI writes placeholders).
+A `.env` file with `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `ARTICLES_SUPABASE_URL`, and `ARTICLES_SUPABASE_ANON_KEY` is required at `flutter_app/.env` (CI writes placeholders; `.env` is gitignored).
 
 ### Web (`web/`)
 ```bash
@@ -55,7 +55,7 @@ The Flutter app is structured as a **mini operating system**, not a traditional 
 
 The web side mirrors this concept (`web/components/OSAppGrid.tsx`, `AppStrip.tsx`, `FloatingNavBar.tsx`, `web/components/apps/`).
 
-### MVP Slim State (as of 2026-04-20, branch `feature/flutter-mvp-slim`)
+### MVP Slim State (as of 2026-04-26, branch `feature/flutter-mvp-slim`)
 
 The app has been slimmed to an App Store MVP. Key runtime differences from the full architecture above:
 
@@ -66,6 +66,10 @@ The app has been slimmed to an App Store MVP. Key runtime differences from the f
 - **Flag-off MicroApps (code in repo, hidden at runtime):** `app_store`, `deep_dive`, `game_reports`, `player_wordle`, `radio`.
 - **Games Timeline removed** from Team Center overlay. Team Center shows: Roster / Depth / Injuries.
 - **`flutter_gemma` / TensorFlow Lite dropped** from `pubspec.yaml` (no MVP consumer; was blocking iOS device builds). `FunctionGemmaService` and `GameReportTools` are stubbed.
+- **Dock is now a floating glass pill** (3 buttons: Home / Schedule / Settings + dividers). Team badge floats above the pill with a 3px brand-green ring. Active tab gets a tinted pill. Extracted into `AppDock` widget (`lib/core/os_shell/widgets/app_dock.dart`); `T4LFloatingNavBar` public API preserved.
+- **Home feed V3**: two card types — `BreakingFeaturedCard` (full-bleed hero) and `BreakingListItemCard` (compact row). Old watermark and section header removed. Cards navigate directly to `BreakingNewsDetailScreen` via `feed_navigation.dart`.
+- **Article detail V3**: `BreakingNewsDetailScreen` has parallax hero, reading-progress bar, byline bar, team chips, player headshots, body text. `AppDock` rendered in `bottomNavigationBar` with `extendBody: true`. Accepts optional `detailFetcher`/`relatedFetcher` typedefs for dependency injection.
+- **Articles backend**: `ArticlesService` (`lib/core/services/articles_service.dart`) targets a new Supabase project (`ARTICLES_SUPABASE_URL`). Uses cursor pagination. Language codes `en`/`de` mapped to BCP-47 `en-US`/`de-DE`. `NewsFeedController` now uses `ArticlesService`; realtime subscription removed.
 
 Full phase-by-phase breakdown: `/Users/tobiaslatta/.claude/plans/snoopy-beaming-swing.md`
 

--- a/flutter_app/changelog/changelog_2026-04-26.md
+++ b/flutter_app/changelog/changelog_2026-04-26.md
@@ -1,0 +1,77 @@
+# Changelog — 2026-04-26
+
+## Summary
+Complete design overhaul of the home feed and article detail experience (V3 handoff), alongside a new dedicated Supabase articles backend with cursor pagination. The dock was rebuilt as a floating glass pill, and home-to-detail navigation is now direct (no sheet).
+
+## Changes
+
+### Home Feed Redesign (V3)
+- Added `BreakingFeaturedCard`: full-bleed hero card with dark-green background, parallax image, gradient overlay, italic Anton headline (via `google_fonts`), BREAKING pill, and READ FULL STORY footer
+- Added `BreakingListItemCard`: compact row card with team logo, category eyebrow, bold headline, and chevron
+- Removed old team-logo watermark and the "BREAKING / Latest / See All" section header from the feed
+- Category eyebrow uses `#4ADE80` in dark mode (`T4LThemeColors`) for contrast compliance
+- Feed cards push `BreakingNewsDetailScreen` directly via new `feed_navigation.dart` helper (converts `NewsFeedItem` → `BreakingNewsArticle`)
+- Deleted unused `news_detail_sheet.dart`
+
+### V3 Floating Dock
+- Rewrote `T4LFloatingNavBar` as a glass pill (3 buttons: Home / Schedule / Settings, with dividers)
+- Team badge floats above the pill (54×54, 3px brand-green ring, overlapping pill by 10px)
+- Active tab renders a brand-tinted pill + green icon/label
+- Fixed Schedule tab alignment with `StackFit.expand` on its Stack wrapper
+- Extracted dock + NavigationService wiring into new `AppDock` widget (`lib/core/os_shell/widgets/app_dock.dart`)
+- Refactored `OSShellView` to use `AppDock`
+- Public `T4LFloatingNavBar` API preserved; added optional `activeTab` param
+
+### V3 Article Detail Screen
+- Rewrote `BreakingNewsDetailScreen` with: full-bleed parallax hero, dark gradient overlay, italic Anton headline, eyebrow pill (BREAKING/UPDATE), 2px reading-progress bar, byline bar (source + date + read-time pill), team chips, player headshots, body text (lead + content), related-stories section
+- Glass back/share floating buttons at top
+- `AppDock` rendered via `bottomNavigationBar` + `extendBody: true` with 140px bottom clearance
+- Detail screen accepts optional `detailFetcher` and `relatedFetcher` typedefs; legacy `BreakingNewsService` remains default; home flow injects `ArticlesService`-backed closures with locale baked in
+
+### Articles Backend (New Supabase Project)
+- New `ArticlesService` (`lib/core/services/articles_service.dart`) targeting `https://aiknjzinyxzhoseyxqev.supabase.co`
+  - `fetchArticles({language, limit, cursor})` returns `ArticlesPage` (cursor pagination)
+  - `fetchArticleDetail(String id, {String? language})` returns `BreakingNewsArticle`
+  - `fetchRelatedStories` is no-op stub (related stories come from the detail payload)
+  - Maps language codes `en`/`de` → BCP-47 `en-US`/`de-DE`
+- `ARTICLES_SUPABASE_URL` and `ARTICLES_SUPABASE_ANON_KEY` added to `flutter_app/.env` (gitignored; CI writes placeholders)
+- `NewsFeedController` rewritten to use `ArticlesService` with cursor pagination; dropped previous Postgres realtime subscription
+- New payload shape (`headline`, `sub_headline`, `introduction`, `content`, `image`, `team`, `mentioned_players[]`, `sources[]`, `created_at`) mapped into existing model types; downstream UI unchanged
+
+### Tests
+- Rewrote `news_feed_controller_test.dart` and `news_feed_widget_test.dart` to mock `ArticlesService`
+- Tests cover: cursor pagination, language-change reload, error rendering
+- Removed previous realtime / `get-news-feed` mock setups
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `lib/core/os_shell/controllers/news_feed_controller.dart` | Rewritten to use `ArticlesService` with cursor pagination; realtime subscription removed |
+| `lib/core/os_shell/views/os_shell_view.dart` | Refactored to use new `AppDock` widget |
+| `lib/core/os_shell/widgets/news_feed/news_feed_widget.dart` | Updated to render `BreakingFeaturedCard` / `BreakingListItemCard`; wires tap to `feed_navigation.dart` |
+| `lib/core/os_shell/widgets/t4l_floating_nav_bar.dart` | Full rewrite as glass pill; optional `activeTab` param added |
+| `lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart` | Full V3 rewrite; optional fetcher typedefs; `AppDock` in bottom bar |
+| `test/core/os_shell/controllers/news_feed_controller_test.dart` | Rewritten for `ArticlesService` mock; cursor + language tests |
+| `test/core/os_shell/widgets/news_feed_widget_test.dart` | Rewritten for `ArticlesService` mock |
+| `lib/core/os_shell/widgets/app_dock.dart` | NEW — extracted dock widget |
+| `lib/core/os_shell/widgets/news_feed/breaking_featured_card.dart` | NEW — V3 hero card |
+| `lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart` | NEW — V3 compact list card |
+| `lib/core/os_shell/widgets/news_feed/feed_navigation.dart` | NEW — `NewsFeedItem` → `BreakingNewsDetailScreen` navigation helper |
+| `lib/core/services/articles_service.dart` | NEW — `ArticlesService` backed by new Supabase project |
+
+## Code Quality Notes
+
+- `flutter analyze --fatal-warnings`: **2 info-level issues, 0 warnings, 0 errors**
+  - `lib/micro_apps/radio/controllers/radio_controller.dart:3` — `unnecessary_import` (pre-existing, unrelated to today's changes)
+  - `test/micro_apps/radio/controllers/radio_controller_test.dart:32` — `use_super_parameters` (pre-existing, unrelated)
+  - CI passes (only errors and warnings are fatal; info is informational)
+- `dart format --set-exit-if-changed .`: **PASSED** — 208 files formatted, 0 changed
+- `flutter test`: **PASSED** — 218 tests passed, 22 skipped (known MVP skips), 0 failures
+
+## Open Items / Carry-over
+
+- `ArticlesService.fetchRelatedStories` is a no-op stub; related stories currently come only from the detail payload (`related_stories` field). A future iteration could fetch them independently or from the list endpoint.
+- `get-article-detail` edge function currently ignores the `language` query param server-side; forwarding it client-side is in place for forward-compat once the function is updated.
+- Two pre-existing info lints in radio (`radio_controller.dart`, `radio_controller_test.dart`) remain unresolved — they are in flag-off code and do not affect CI.
+- `news_detail_sheet.dart` was deleted; if any other call site referenced it, it would have surfaced as a compile error in analyze — confirmed clean.

--- a/flutter_app/ios/Podfile.lock
+++ b/flutter_app/ios/Podfile.lock
@@ -6,26 +6,12 @@ PODS:
     - FlutterMacOS
   - audio_session (0.0.1):
     - Flutter
-  - background_downloader (0.0.1):
-    - Flutter
   - Flutter (1.0.0)
-  - flutter_gemma (0.11.16):
-    - Flutter
-    - MediaPipeTasksGenAI (= 0.10.24)
-    - MediaPipeTasksGenAIC (= 0.10.24)
-    - TensorFlowLiteC (= 0.0.1-nightly.20250619)
-    - TensorFlowLiteSelectTfOps (= 0.0.1-nightly.20250619)
-    - TensorFlowLiteSwift (= 0.0.1-nightly.20250619)
   - flutter_local_notifications (0.0.1):
     - Flutter
   - just_audio (0.0.1):
     - Flutter
     - FlutterMacOS
-  - large_file_handler (0.0.1):
-    - Flutter
-  - MediaPipeTasksGenAI (0.10.24):
-    - MediaPipeTasksGenAIC (= 0.10.24)
-  - MediaPipeTasksGenAIC (0.10.24)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -40,16 +26,6 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
-  - TensorFlowLiteC (0.0.1-nightly.20250619):
-    - TensorFlowLiteC/Core (= 0.0.1-nightly.20250619)
-  - TensorFlowLiteC/Core (0.0.1-nightly.20250619)
-  - TensorFlowLiteSelectTfOps (0.0.1-nightly.20250619)
-  - TensorFlowLiteSwift (0.0.1-nightly.20250619):
-    - TensorFlowLiteSwift/Core (= 0.0.1-nightly.20250619)
-  - TensorFlowLiteSwift/Core (0.0.1-nightly.20250619):
-    - TensorFlowLiteC (= 0.0.1-nightly.20250619)
-    - TensorFlowLiteSwift/Privacy (= 0.0.1-nightly.20250619)
-  - TensorFlowLiteSwift/Privacy (0.0.1-nightly.20250619)
   - Try (2.1.1)
   - url_launcher_ios (0.0.1):
     - Flutter
@@ -61,12 +37,9 @@ DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
   - audio_service (from `.symlinks/plugins/audio_service/darwin`)
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
-  - background_downloader (from `.symlinks/plugins/background_downloader/ios`)
   - Flutter (from `Flutter`)
-  - flutter_gemma (from `.symlinks/plugins/flutter_gemma/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
-  - large_file_handler (from `.symlinks/plugins/large_file_handler/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -77,11 +50,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - MediaPipeTasksGenAI
-    - MediaPipeTasksGenAIC
-    - TensorFlowLiteC
-    - TensorFlowLiteSelectTfOps
-    - TensorFlowLiteSwift
     - Try
 
 EXTERNAL SOURCES:
@@ -91,18 +59,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/audio_service/darwin"
   audio_session:
     :path: ".symlinks/plugins/audio_session/ios"
-  background_downloader:
-    :path: ".symlinks/plugins/background_downloader/ios"
   Flutter:
     :path: Flutter
-  flutter_gemma:
-    :path: ".symlinks/plugins/flutter_gemma/ios"
   flutter_local_notifications:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   just_audio:
     :path: ".symlinks/plugins/just_audio/darwin"
-  large_file_handler:
-    :path: ".symlinks/plugins/large_file_handler/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   share_plus:
@@ -122,22 +84,14 @@ SPEC CHECKSUMS:
   app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   audio_service: aa99a6ba2ae7565996015322b0bb024e1d25c6fd
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
-  background_downloader: 50e91d979067b82081aba359d7d916b3ba5fadad
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_gemma: a61bb8893b6b77e1088ec27ed519a0711fc84c30
   flutter_local_notifications: ad39620c743ea4c15127860f4b5641649a988100
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  large_file_handler: b37481e9b4972562ffcdc8f75700f47cd592bcec
-  MediaPipeTasksGenAI: 076ba7032a6e9da16db9c7cf0c3b67c751c18bc1
-  MediaPipeTasksGenAIC: ec35d9f431f6a6b651a0bc9f67a4ed149ffa575c
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   speech_to_text: ae2abc312e619ff1c53e675a9fc4d785a15c03bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  TensorFlowLiteC: 215ef57653dd0fa09a474e7d94d79ae64a870b28
-  TensorFlowLiteSelectTfOps: c71d7dcd063f5d66ae1b9a85cc5aa993f824eff9
-  TensorFlowLiteSwift: 6de8da348de331778167a0f751ad74c41d8b0554
   Try: 5ef669ae832617b3cee58cb2c6f99fb767a4ff96
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
   video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b

--- a/flutter_app/lib/core/onboarding/views/first_launch_flow.dart
+++ b/flutter_app/lib/core/onboarding/views/first_launch_flow.dart
@@ -1,0 +1,348 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../models/team_model.dart';
+import '../../services/settings_service.dart';
+import '../../services/team_service.dart';
+import '../../theme/t4l_theme.dart';
+import 'package:tackle4loss_mobile/design_tokens.dart';
+
+/// Mandatory first-launch flow.
+///
+/// Two non-dismissible steps — team selection then language confirmation —
+/// then writes `onboarding_complete_v1 = true` via [SettingsService] and
+/// returns control to the OS Shell. The system back gesture is intercepted
+/// (`canPop: false`) so reviewers and users cannot bypass the picker.
+class FirstLaunchFlow extends StatefulWidget {
+  const FirstLaunchFlow({super.key});
+
+  @override
+  State<FirstLaunchFlow> createState() => _FirstLaunchFlowState();
+}
+
+enum _OnboardingStep { team, language }
+
+class _FirstLaunchFlowState extends State<FirstLaunchFlow> {
+  _OnboardingStep _step = _OnboardingStep.team;
+  Team? _pendingTeam;
+  Locale? _pendingLocale;
+
+  @override
+  void initState() {
+    super.initState();
+    final settings = context.read<SettingsService>();
+    _pendingTeam = settings.selectedTeam;
+    _pendingLocale = settings.locale;
+  }
+
+  Future<void> _confirm() async {
+    final settings = context.read<SettingsService>();
+    if (_pendingTeam != null) {
+      await settings.setFavoriteTeam(_pendingTeam!);
+    }
+    if (_pendingLocale != null) {
+      settings.setLocale(_pendingLocale!);
+    }
+    await settings.markOnboardingComplete();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<T4LThemeColors>()!;
+
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        backgroundColor: colors.surface,
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+            child: _step == _OnboardingStep.team
+                ? _TeamStep(
+                    selected: _pendingTeam,
+                    onSelect: (team) => setState(() => _pendingTeam = team),
+                    onContinue: _pendingTeam == null
+                        ? null
+                        : () => setState(
+                            () => _step = _OnboardingStep.language),
+                  )
+                : _LanguageStep(
+                    selected: _pendingLocale ?? const Locale('en'),
+                    onSelect: (locale) =>
+                        setState(() => _pendingLocale = locale),
+                    onBack: () => setState(() => _step = _OnboardingStep.team),
+                    onFinish: () async {
+                      await _confirm();
+                    },
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TeamStep extends StatelessWidget {
+  final Team? selected;
+  final ValueChanged<Team> onSelect;
+  final VoidCallback? onContinue;
+
+  const _TeamStep({
+    required this.selected,
+    required this.onSelect,
+    required this.onContinue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final teams = TeamService().getTeams();
+    final colors = Theme.of(context).extension<T4LThemeColors>()!;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'WELCOME TO TACKLE 4 LOSS',
+          style: TextStyle(
+            color: colors.textSecondary,
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 2.0,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Pick your team',
+          style: TextStyle(
+            color: colors.textPrimary,
+            fontSize: 28,
+            fontWeight: FontWeight.w900,
+            height: 1.1,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'You can change this later in Settings.',
+          style: TextStyle(
+            color: colors.textSecondary,
+            fontSize: 14,
+          ),
+        ),
+        const SizedBox(height: 24),
+        Expanded(
+          child: GridView.builder(
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 3,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 16,
+              childAspectRatio: 1,
+            ),
+            itemCount: teams.length,
+            itemBuilder: (context, index) {
+              final team = teams[index];
+              final isSelected = selected?.id == team.id;
+              return GestureDetector(
+                onTap: () => onSelect(team),
+                child: Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? team.primaryColor.withValues(alpha: 0.2)
+                        : (isDark
+                            ? Colors.white.withValues(alpha: 0.05)
+                            : Colors.black.withValues(alpha: 0.03)),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(
+                      color: isSelected
+                          ? team.primaryColor
+                          : (isDark ? Colors.white10 : Colors.black12),
+                      width: 2,
+                    ),
+                  ),
+                  child: Container(
+                    padding: const EdgeInsets.all(8.0),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: isDark ? Colors.white : Colors.transparent,
+                    ),
+                    child: Image.asset(
+                      team.logoUrl,
+                      fit: BoxFit.contain,
+                      errorBuilder: (context, error, stackTrace) => Icon(
+                        Icons.error_outline,
+                        color: isDark ? Colors.black26 : Colors.grey,
+                        size: 20,
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            onPressed: onContinue,
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+            ),
+            child: const Text(
+              'CONTINUE',
+              style: TextStyle(
+                fontWeight: FontWeight.w800,
+                letterSpacing: 1.5,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _LanguageStep extends StatelessWidget {
+  final Locale selected;
+  final ValueChanged<Locale> onSelect;
+  final VoidCallback onBack;
+  final Future<void> Function() onFinish;
+
+  const _LanguageStep({
+    required this.selected,
+    required this.onSelect,
+    required this.onBack,
+    required this.onFinish,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<T4LThemeColors>()!;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'STEP 2 OF 2',
+          style: TextStyle(
+            color: colors.textSecondary,
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 2.0,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Confirm your language',
+          style: TextStyle(
+            color: colors.textPrimary,
+            fontSize: 28,
+            fontWeight: FontWeight.w900,
+            height: 1.1,
+          ),
+        ),
+        const SizedBox(height: 24),
+        _LanguageTile(
+          label: 'English',
+          isSelected: selected.languageCode == 'en',
+          onTap: () => onSelect(const Locale('en')),
+        ),
+        const SizedBox(height: 12),
+        _LanguageTile(
+          label: 'Deutsch',
+          isSelected: selected.languageCode == 'de',
+          onTap: () => onSelect(const Locale('de')),
+        ),
+        const Spacer(),
+        Row(
+          children: [
+            TextButton(
+              onPressed: onBack,
+              child: Text(
+                'BACK',
+                style: TextStyle(color: colors.textSecondary),
+              ),
+            ),
+            const Spacer(),
+            FilledButton(
+              onPressed: onFinish,
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 32, vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+              child: const Text(
+                'GET STARTED',
+                style: TextStyle(
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 1.5,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _LanguageTile extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _LanguageTile({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).extension<T4LThemeColors>()!;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? AppColors.primary.withValues(alpha: 0.12)
+              : (isDark
+                  ? Colors.white.withValues(alpha: 0.05)
+                  : Colors.black.withValues(alpha: 0.03)),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: isSelected
+                ? AppColors.primary
+                : (isDark ? Colors.white10 : Colors.black12),
+            width: 2,
+          ),
+        ),
+        child: Row(
+          children: [
+            Text(
+              label,
+              style: TextStyle(
+                color: colors.textPrimary,
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const Spacer(),
+            if (isSelected)
+              const Icon(Icons.check_circle, color: AppColors.primary),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/core/onboarding/views/first_launch_flow.dart
+++ b/flutter_app/lib/core/onboarding/views/first_launch_flow.dart
@@ -62,8 +62,8 @@ class _FirstLaunchFlowState extends State<FirstLaunchFlow> {
                     onSelect: (team) => setState(() => _pendingTeam = team),
                     onContinue: _pendingTeam == null
                         ? null
-                        : () => setState(
-                            () => _step = _OnboardingStep.language),
+                        : () =>
+                            setState(() => _step = _OnboardingStep.language),
                   )
                 : _LanguageStep(
                     selected: _pendingLocale ?? const Locale('en'),
@@ -272,8 +272,8 @@ class _LanguageStep extends StatelessWidget {
               onPressed: onFinish,
               style: FilledButton.styleFrom(
                 backgroundColor: AppColors.primary,
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 32, vertical: 16),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
                 ),

--- a/flutter_app/lib/core/os_shell/controllers/news_feed_controller.dart
+++ b/flutter_app/lib/core/os_shell/controllers/news_feed_controller.dart
@@ -1,143 +1,46 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:flutter/foundation.dart';
 import '../../models/news_feed_item.dart';
+import '../../services/articles_service.dart';
 
-/// Controller for managing news feed state and pagination
-/// Supports multiple content types via FeedItem base class
-/// Subscribes to real-time updates from content.news_updates table
+/// Controller for the home-screen news feed, backed by the dedicated
+/// "articles" Supabase project (`get-articles` edge function with cursor
+/// pagination).
 class NewsFeedController extends ChangeNotifier {
   final String languageCode;
   final int _pageSize = 20;
+  final ArticlesService _articlesService;
 
   List<FeedItem> _items = [];
   bool _isLoading = false;
   bool _hasMore = true;
   String? _error;
-  int _offset = 0;
+  ArticlesCursor? _cursor;
 
   /// Set of item IDs for efficient de-duplication
   final Set<String> _itemIds = {};
 
-  /// Supabase Client to use (injectable for testing)
-  final SupabaseClient supabaseClient;
-
-  /// Supabase Realtime channel for listening to new news updates
-  RealtimeChannel? _realtimeChannel;
-
   NewsFeedController({
     required this.languageCode,
-    SupabaseClient? client,
-  }) : supabaseClient = client ?? Supabase.instance.client;
+    ArticlesService? articlesService,
+  }) : _articlesService = articlesService ?? ArticlesService();
 
   List<FeedItem> get items => _items;
   bool get isLoading => _isLoading;
   bool get hasMore => _hasMore;
   String? get error => _error;
 
-  /// Load initial set of news feed items and subscribe to realtime updates
+  /// Load the first page of articles.
   Future<void> loadInitial() async {
-    _offset = 0;
     _items = [];
     _itemIds.clear();
+    _cursor = null;
     _hasMore = true;
     _error = null;
-
-    // Subscribe to realtime updates
-    _subscribeToRealtimeUpdates();
-
     await _fetchPage();
   }
 
-  /// Subscribe to INSERT events on content.news_updates table
-  void _subscribeToRealtimeUpdates() {
-    // Remove existing subscription if any
-    _unsubscribeFromRealtime();
-
-    _realtimeChannel = supabaseClient
-        .channel('news-feed-updates')
-        .onPostgresChanges(
-          event: PostgresChangeEvent.insert,
-          schema: 'content',
-          table: 'news_updates',
-          callback: (payload) {
-            _handleRealtimeInsert(payload.newRecord);
-          },
-        )
-        .subscribe();
-  }
-
-  /// Handle a new item inserted via realtime
-  void _handleRealtimeInsert(Map<String, dynamic> newRecord) {
-    // Check if the new item matches our language filter
-    final recordLanguageCode = newRecord['language_code'] as String?;
-    if (recordLanguageCode != null && recordLanguageCode != languageCode) {
-      return; // Ignore items for other languages
-    }
-
-    // Check if we already have this item (avoid duplicates)
-    final newId = newRecord['id']?.toString();
-    if (newId == null || _itemIds.contains(newId)) {
-      return;
-    }
-
-    // Construct the item directly from the realtime payload
-    // Note: This won't have enriched data (source name, player headshots)
-    // but the item will be fully enriched on next refresh
-    try {
-      final newItem = _createItemFromPayload(newRecord);
-      if (newItem != null) {
-        _items.insert(0, newItem);
-        _itemIds.add(newItem.id);
-        _offset += 1; // Adjust offset to account for new item
-        notifyListeners();
-      }
-    } catch (e) {
-      // Silently fail - the item will appear on next refresh
-      debugPrint('Failed to create item from realtime payload: $e');
-    }
-  }
-
-  /// Create a NewsFeedItem from the realtime payload
-  /// Returns null if the payload cannot be parsed
-  NewsFeedItem? _createItemFromPayload(Map<String, dynamic> record) {
-    final id = record['id']?.toString();
-    final createdAt = record['created_at'] as String?;
-
-    if (id == null || createdAt == null) return null;
-
-    // Build the image URL if image_file is present
-    String? imageUrl = record['image_file'] as String?;
-    if (imageUrl != null && !imageUrl.startsWith('http')) {
-      // Construct full URL using dotenv
-      final supabaseUrl = dotenv.env['SUPABASE_URL'] ?? '';
-      imageUrl = '$supabaseUrl/storage/v1/object/public/content/$imageUrl';
-    }
-
-    return NewsFeedItem(
-      id: id,
-      xPost: record['x_post'] as String? ?? '',
-      imageUrl: imageUrl,
-      source:
-          null, // Not available in realtime payload, will be enriched on refresh
-      headline: record['headline'] as String?,
-      status: record['status'] as String?,
-      players: record['players'] as List<dynamic>?,
-      teams: record['teams'] as List<dynamic>?,
-      createdAt: DateTime.parse(createdAt),
-    );
-  }
-
-  /// Unsubscribe from realtime channel
-  void _unsubscribeFromRealtime() {
-    if (_realtimeChannel != null) {
-      supabaseClient.removeChannel(_realtimeChannel!);
-      _realtimeChannel = null;
-    }
-  }
-
-  /// Load next page of news feed items
+  /// Load next page of articles.
   Future<void> loadMore() async {
     if (_isLoading || !_hasMore) return;
     await _fetchPage();
@@ -149,38 +52,21 @@ class NewsFeedController extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final response = await supabaseClient.functions.invoke(
-        'get-news-feed',
-        body: {
-          'language_code': languageCode,
-          'limit': _pageSize,
-          'offset': _offset,
-        },
+      final page = await _articlesService.fetchArticles(
+        language: languageCode,
+        limit: _pageSize,
+        cursor: _cursor,
       );
 
-      if (response.status != 200) {
-        throw Exception('Failed to load news feed');
-      }
-
-      final data = response.data as Map<String, dynamic>;
-      final List<dynamic> itemsJson = data['items'] as List<dynamic>;
-      final newItems = itemsJson
-          .map((json) => FeedItem.fromJson(json as Map<String, dynamic>))
-          .toList();
-
-      // De-duplicate: only add items we don't already have
-      // This handles the race condition where realtime adds an item
-      // that's also in the paginated results
-      for (final item in newItems) {
+      for (final item in page.items) {
         if (!_itemIds.contains(item.id)) {
           _items.add(item);
           _itemIds.add(item.id);
         }
       }
 
-      _hasMore = data['hasMore'] as bool? ?? false;
-      _offset +=
-          newItems.length; // Advance offset by fetched count, not added count
+      _cursor = page.nextCursor;
+      _hasMore = page.nextCursor != null;
     } catch (e) {
       _error = e.toString();
     } finally {
@@ -189,14 +75,7 @@ class NewsFeedController extends ChangeNotifier {
     }
   }
 
-  /// Refresh the feed from the beginning
   Future<void> refresh() async {
     await loadInitial();
-  }
-
-  @override
-  void dispose() {
-    _unsubscribeFromRealtime();
-    super.dispose();
   }
 }

--- a/flutter_app/lib/core/os_shell/controllers/os_shell_controller.dart
+++ b/flutter_app/lib/core/os_shell/controllers/os_shell_controller.dart
@@ -1,18 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../micro_app.dart';
-import '../../../../micro_apps/deep_dive/models/deep_dive_article.dart';
 
 class OSShellController extends ChangeNotifier {
   final BuildContext context;
-  DeepDiveArticle? _featuredArticle;
-  bool _isLoadingFeatured = false;
   bool _isPageReady = false;
 
   OSShellController(this.context);
 
-  DeepDiveArticle? get featuredArticle => _featuredArticle;
-  bool get isLoadingFeatured => _isLoadingFeatured;
   bool get isPageReady => _isPageReady;
 
   bool _mounted = true;
@@ -23,40 +17,10 @@ class OSShellController extends ChangeNotifier {
     super.dispose();
   }
 
-  Future<void> loadFeaturedContent(String languageCode) async {
-    _isLoadingFeatured = true;
-    if (_mounted) notifyListeners();
-
-    try {
-      final response = await Supabase.instance.client.functions.invoke(
-        'get-latest-deepdive',
-        body: {'language_code': languageCode},
-      );
-
-      if (_mounted && response.data != null) {
-        _featuredArticle = DeepDiveArticle.fromJson(response.data);
-      }
-    } catch (e) {
-      debugPrint('Error loading featured content: $e');
-    } finally {
-      if (_mounted) {
-        _isLoadingFeatured = false;
-        notifyListeners();
-      }
-    }
-  }
-
-  /// Load all page data in parallel, notify when complete.
-  /// This should be called from the view's initState or didChangeDependencies.
+  /// Resolve the page-ready signal. Kept as an async hook so future MVP
+  /// data sources (e.g. an explicit news feed warm-up) can be awaited
+  /// here without changing the call site in OSShellView.
   Future<void> initLoadAll(String languageCode) async {
-    _isPageReady = false;
-    if (_mounted) notifyListeners();
-
-    await Future.wait([
-      loadFeaturedContent(languageCode),
-      // Add other data sources here as needed
-    ]);
-
     if (_mounted) {
       _isPageReady = true;
       notifyListeners();

--- a/flutter_app/lib/core/os_shell/views/os_shell_view.dart
+++ b/flutter_app/lib/core/os_shell/views/os_shell_view.dart
@@ -106,7 +106,6 @@ class _OSShellViewState extends State<OSShellView>
                   homeTooltip: AppLocalizations.of(context)!.navHome,
                   gameCenterTooltip:
                       AppLocalizations.of(context)!.navGameCenter,
-                  historyTooltip: AppLocalizations.of(context)!.navHistory,
                   settingsTooltip: AppLocalizations.of(context)!.navSettings,
                   favoriteTeamLogoUrl: settings.selectedTeam?.logoUrl,
                   showGameCenterBadge: false, // No badge for Game Center
@@ -114,7 +113,6 @@ class _OSShellViewState extends State<OSShellView>
                   onGameCenter: () {
                     NavigationService().openGameCenter(context);
                   },
-                  onHistory: () => NavigationService().reopenLastApp(context),
                   onSettings: () {
                     NavigationService().openSettings(
                       context,

--- a/flutter_app/lib/core/os_shell/views/os_shell_view.dart
+++ b/flutter_app/lib/core/os_shell/views/os_shell_view.dart
@@ -1,17 +1,11 @@
 import 'package:flutter/material.dart';
-import '../../services/new_content_service.dart';
 import '../controllers/os_shell_controller.dart';
-import '../../services/navigation_service.dart';
-import '../widgets/t4l_floating_nav_bar.dart';
+import '../widgets/app_dock.dart';
 import '../widgets/t4l_scaffold.dart';
 import 'package:provider/provider.dart';
 import '../../services/settings_service.dart';
 import '../widgets/news_feed/news_feed_widget.dart';
-import '../../../l10n/app_localizations.dart';
 
-import '../../team_center/views/team_center_overlay.dart';
-import '../widgets/user_settings_dialog.dart';
-import '../widgets/team_selector_dialog.dart';
 import '../../widgets/shimmer_skeleton.dart';
 
 class OSShellView extends StatefulWidget {
@@ -73,8 +67,6 @@ class _OSShellViewState extends State<OSShellView>
 
   @override
   Widget build(BuildContext context) {
-    final settings = Provider.of<SettingsService>(context);
-
     // Re-initialize animations on hot reload if needed
     _rotationController ??= AnimationController(
       duration: const Duration(seconds: 6),
@@ -90,49 +82,7 @@ class _OSShellViewState extends State<OSShellView>
       value: _controller,
       child: T4LScaffold(
         showCloseButton: false, // Shell is the root
-        bottomNavBarOverride: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // MVP: App Strip removed; Dock is the only bottom nav surface.
-            ListenableBuilder(
-              listenable: NewContentService(),
-              builder: (context, child) {
-                return T4LFloatingNavBar(
-                  homeTooltip: AppLocalizations.of(context)!.navHome,
-                  gameCenterTooltip:
-                      AppLocalizations.of(context)!.navGameCenter,
-                  settingsTooltip: AppLocalizations.of(context)!.navSettings,
-                  favoriteTeamLogoUrl: settings.selectedTeam?.logoUrl,
-                  showGameCenterBadge: false, // No badge for Game Center
-                  onHome: () => NavigationService().goHome(context),
-                  onGameCenter: () {
-                    NavigationService().openGameCenter(context);
-                  },
-                  onSettings: () {
-                    NavigationService().openSettings(
-                      context,
-                      (context) => const UserSettingsDialog(),
-                    );
-                  },
-                  onTeamLogo: () {
-                    if (settings.selectedTeam == null) {
-                      NavigationService().openTeamSelector(
-                        context,
-                        (context) => const TeamSelectorDialog(),
-                      );
-                    } else {
-                      NavigationService().openTeamCenter(
-                        context,
-                        () => TeamCenterOverlay.show(
-                            context, settings.selectedTeam!),
-                      );
-                    }
-                  },
-                );
-              },
-            ),
-          ],
-        ),
+        bottomNavBarOverride: const AppDock(),
         body: SafeArea(
           child: Stack(
             children: [

--- a/flutter_app/lib/core/os_shell/views/os_shell_view.dart
+++ b/flutter_app/lib/core/os_shell/views/os_shell_view.dart
@@ -13,8 +13,6 @@ import '../../team_center/views/team_center_overlay.dart';
 import '../widgets/user_settings_dialog.dart';
 import '../widgets/team_selector_dialog.dart';
 import '../../widgets/shimmer_skeleton.dart';
-import '../widgets/app_strip.dart';
-import '../../../micro_apps/radio/views/widgets/radio_home_widget.dart';
 
 class OSShellView extends StatefulWidget {
   const OSShellView({super.key});
@@ -95,10 +93,7 @@ class _OSShellViewState extends State<OSShellView>
         bottomNavBarOverride: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // 1. App Strip (Horizontal browse)
-            const AppStrip(),
-
-            // 2. Persistent Dock
+            // MVP: App Strip removed; Dock is the only bottom nav surface.
             ListenableBuilder(
               listenable: NewContentService(),
               builder: (context, child) {
@@ -152,34 +147,18 @@ class _OSShellViewState extends State<OSShellView>
                     return const OSShellSkeleton();
                   }
 
-                  return CustomScrollView(
-                    physics: const AlwaysScrollableScrollPhysics(),
+                  return const CustomScrollView(
+                    physics: AlwaysScrollableScrollPhysics(),
                     slivers: [
-                      // Header Clearance
                       // Header Clearance (Handled by T4LScaffold)
-                      const SliverToBoxAdapter(child: SizedBox(height: 0)),
+                      SliverToBoxAdapter(child: SizedBox(height: 0)),
 
-                      // Pinned Rich Widgets at the top of the feed
+                      // News Feed (MVP home content)
+                      NewsFeedWidget(),
+
+                      // Bottom Clearance for the Dock
                       SliverPadding(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 24, vertical: 16),
-                        sliver: SliverList(
-                          delegate: SliverChildListDelegate([
-                            // Radio Widget (Compact)
-                            const SizedBox(
-                              height: 74,
-                              child: RadioHomeWidget(),
-                            ),
-                          ]),
-                        ),
-                      ),
-
-                      // News Feed
-                      const NewsFeedWidget(),
-
-                      // Bottom Clearance for AppStrip + Dock
-                      const SliverPadding(
-                        padding: EdgeInsets.only(bottom: 220),
+                        padding: EdgeInsets.only(bottom: 140),
                       ),
                     ],
                   );

--- a/flutter_app/lib/core/os_shell/widgets/app_dock.dart
+++ b/flutter_app/lib/core/os_shell/widgets/app_dock.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../services/navigation_service.dart';
+import '../../services/new_content_service.dart';
+import '../../services/settings_service.dart';
+import '../../team_center/views/team_center_overlay.dart';
+import 't4l_floating_nav_bar.dart';
+import 'team_selector_dialog.dart';
+import 'user_settings_dialog.dart';
+
+/// Standard app-wide floating dock with the canonical NavigationService
+/// wiring (Home / Schedule / Settings + team badge). Reused by the OS shell
+/// and any deep screen (e.g. the breaking-news detail) that should keep the
+/// global navigation visible.
+class AppDock extends StatelessWidget {
+  final T4LNavTab activeTab;
+
+  const AppDock({super.key, this.activeTab = T4LNavTab.home});
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = Provider.of<SettingsService>(context);
+    final l10n = AppLocalizations.of(context);
+
+    return ListenableBuilder(
+      listenable: NewContentService(),
+      builder: (context, _) {
+        return T4LFloatingNavBar(
+          activeTab: activeTab,
+          homeTooltip: l10n?.navHome,
+          gameCenterTooltip: l10n?.navGameCenter,
+          settingsTooltip: l10n?.navSettings,
+          favoriteTeamLogoUrl: settings.selectedTeam?.logoUrl,
+          showGameCenterBadge: false,
+          onHome: () => NavigationService().goHome(context),
+          onGameCenter: () => NavigationService().openGameCenter(context),
+          onSettings: () => NavigationService().openSettings(
+            context,
+            (context) => const UserSettingsDialog(),
+          ),
+          onTeamLogo: () {
+            if (settings.selectedTeam == null) {
+              NavigationService().openTeamSelector(
+                context,
+                (context) => const TeamSelectorDialog(),
+              );
+            } else {
+              NavigationService().openTeamCenter(
+                context,
+                () => TeamCenterOverlay.show(context, settings.selectedTeam!),
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_featured_card.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_featured_card.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:tackle4loss_mobile/design_tokens.dart';
+import '../../../models/news_feed_item.dart';
+import '../../../services/team_logo_service.dart';
+import 'feed_navigation.dart';
+
+class BreakingFeaturedCard extends StatefulWidget {
+  final NewsFeedItem item;
+
+  const BreakingFeaturedCard({super.key, required this.item});
+
+  @override
+  State<BreakingFeaturedCard> createState() => _BreakingFeaturedCardState();
+}
+
+class _BreakingFeaturedCardState extends State<BreakingFeaturedCard>
+    with SingleTickerProviderStateMixin {
+  bool _pressed = false;
+  late final AnimationController _pulse = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1200),
+  )..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final firstTeamId = (item.teams != null && item.teams!.isNotEmpty)
+        ? item.teams!.first['team_id']?.toString().toLowerCase() ?? ''
+        : '';
+    final headline = (item.headline ?? item.xPost).toUpperCase();
+    final category = (item.headline ?? 'BREAKING').toUpperCase();
+    final timeLabel = _timeAgo(item.createdAt);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
+      child: GestureDetector(
+        onTapDown: (_) => setState(() => _pressed = true),
+        onTapCancel: () => setState(() => _pressed = false),
+        onTapUp: (_) {
+          setState(() => _pressed = false);
+          openNewsItemDetail(context, item);
+        },
+        child: AnimatedScale(
+          scale: _pressed ? 0.985 : 1.0,
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOut,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(20),
+            child: Container(
+              decoration: const BoxDecoration(
+                color: Color(0xFF0A1E13),
+                boxShadow: [
+                  BoxShadow(
+                    color: Color(0x380A1E16),
+                    blurRadius: 40,
+                    offset: Offset(0, 12),
+                  ),
+                ],
+              ),
+              child: Stack(
+                fit: StackFit.passthrough,
+                children: [
+                  if (item.imageUrl != null)
+                    Positioned.fill(
+                      child: CachedNetworkImage(
+                        imageUrl: item.imageUrl!,
+                        fit: BoxFit.cover,
+                        memCacheWidth: 800,
+                        fadeInDuration: const Duration(milliseconds: 250),
+                      ),
+                    ),
+                  Positioned.fill(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: item.imageUrl != null
+                              ? const [
+                                  Color(0x660A1E13),
+                                  Color(0xCC0A1E13),
+                                  Color(0xF20A1E13),
+                                ]
+                              : const [
+                                  Color(0xFF0A1E13),
+                                  Color(0xFF183D28),
+                                  Color(0xFF0F2D1D),
+                                ],
+                          stops: const [0.0, 0.55, 1.0],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: CustomPaint(
+                      painter: _FieldLinesPainter(),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(18, 18, 18, 20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Row(
+                          children: [
+                            _breakingPill(),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                category,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontSize: 9,
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 1.2,
+                                  color: Color(0x73FFFFFF),
+                                ),
+                              ),
+                            ),
+                            Text(
+                              timeLabel,
+                              style: const TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                color: Color(0x59FFFFFF),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        if (firstTeamId.isNotEmpty)
+                          Container(
+                            width: 36,
+                            height: 36,
+                            margin: const EdgeInsets.only(bottom: 10),
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            padding: const EdgeInsets.all(4),
+                            child: Image.asset(
+                              TeamLogoService.getLogoPath(firstTeamId),
+                              fit: BoxFit.contain,
+                              errorBuilder: (_, __, ___) => const SizedBox(),
+                            ),
+                          ),
+                        if (item.imageUrl != null) const SizedBox(height: 80),
+                        Text(
+                          headline,
+                          style: GoogleFonts.anton(
+                            fontSize: 26,
+                            height: 0.97,
+                            letterSpacing: -0.3,
+                            color: Colors.white,
+                            fontStyle: FontStyle.italic,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          item.xPost,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 13,
+                            height: 1.45,
+                            color: Color(0x8CFFFFFF),
+                          ),
+                        ),
+                        const SizedBox(height: 14),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Container(
+                                height: 1,
+                                color: const Color(0x1AFFFFFF),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            const Text(
+                              'READ FULL STORY',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 1.2,
+                                color: Color(0xCCC9A256),
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            const Icon(Icons.chevron_right,
+                                size: 16, color: Color(0xCCC9A256)),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _breakingPill() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppColors.breakingNewsRedBright.withValues(alpha: 0.20),
+        border: Border.all(
+            color: AppColors.breakingNewsRedBright.withValues(alpha: 0.40)),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FadeTransition(
+            opacity: Tween<double>(begin: 1.0, end: 0.45).animate(_pulse),
+            child: Container(
+              width: 6,
+              height: 6,
+              decoration: const BoxDecoration(
+                color: AppColors.breakingNewsRedBright,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          const SizedBox(width: 5),
+          const Text(
+            'BREAKING',
+            style: TextStyle(
+              fontSize: 9,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 1.4,
+              color: AppColors.breakingNewsRedBright,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _timeAgo(DateTime dt) {
+    final d = DateTime.now().difference(dt.toLocal());
+    if (d.inMinutes < 60) return '${d.inMinutes}m ago';
+    if (d.inHours < 24) return '${d.inHours}h ago';
+    if (d.inDays < 7) return '${d.inDays}d ago';
+    return '${dt.month}/${dt.day}';
+  }
+}
+
+class _FieldLinesPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white.withValues(alpha: 0.05)
+      ..strokeWidth = 1;
+    const cols = 8;
+    final dx = size.width / cols;
+    for (var i = 0; i <= cols; i++) {
+      canvas.drawLine(Offset(i * dx, 0), Offset(i * dx, size.height), paint);
+    }
+    final mid = Paint()
+      ..color = Colors.white.withValues(alpha: 0.05)
+      ..strokeWidth = 1.5;
+    canvas.drawLine(
+        Offset(0, size.height / 2), Offset(size.width, size.height / 2), mid);
+  }
+
+  @override
+  bool shouldRepaint(covariant _FieldLinesPainter oldDelegate) => false;
+}

--- a/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:tackle4loss_mobile/design_tokens.dart';
+import '../../../models/news_feed_item.dart';
+import '../../../services/team_logo_service.dart';
+import '../../../theme/t4l_theme.dart';
+import 'feed_navigation.dart';
+
+class BreakingListItemCard extends StatefulWidget {
+  final NewsFeedItem item;
+  final bool isLast;
+
+  const BreakingListItemCard(
+      {super.key, required this.item, this.isLast = false});
+
+  @override
+  State<BreakingListItemCard> createState() => _BreakingListItemCardState();
+}
+
+class _BreakingListItemCardState extends State<BreakingListItemCard> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final theme = Theme.of(context);
+    final t4l = theme.extension<T4LThemeColors>();
+    final isDark = theme.brightness == Brightness.dark;
+    final textPrimary = t4l?.textPrimary ?? AppColors.neutralText;
+    final textMuted = isDark
+        ? Colors.white.withValues(alpha: 0.55)
+        : (t4l?.textMuted ?? AppColors.neutralTextLight);
+    final brand = t4l?.brand ?? AppColors.brandBase;
+    // Dark mode: use a bright accent so the category eyebrow stays readable on
+    // the dark navy background (matches the V3 dock active green).
+    final categoryColor = isDark ? const Color(0xFF4ADE80) : brand;
+    final badgeBg =
+        isDark ? Colors.white.withValues(alpha: 0.06) : AppColors.neutralSoft;
+    final divider =
+        (isDark ? Colors.white : AppColors.brandBase).withValues(alpha: 0.08);
+    final pressBg =
+        (isDark ? Colors.white : AppColors.brandBase).withValues(alpha: 0.04);
+
+    final firstTeamId = (item.teams != null && item.teams!.isNotEmpty)
+        ? item.teams!.first['team_id']?.toString().toLowerCase() ?? ''
+        : '';
+    final cat = (item.headline ?? 'NEWS').toUpperCase();
+    final timeLabel = _timeAgo(item.createdAt);
+
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapCancel: () => setState(() => _pressed = false),
+      onTapUp: (_) {
+        setState(() => _pressed = false);
+        openNewsItemDetail(context, item);
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 100),
+        padding: const EdgeInsets.fromLTRB(20, 13, 20, 13),
+        decoration: BoxDecoration(
+          color: _pressed ? pressBg : Colors.transparent,
+          border: Border(
+            bottom: widget.isLast
+                ? BorderSide.none
+                : BorderSide(color: divider, width: 1),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 38,
+              height: 38,
+              margin: const EdgeInsets.only(top: 1),
+              decoration: BoxDecoration(
+                color: badgeBg,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: brand.withValues(alpha: 0.12)),
+              ),
+              padding: const EdgeInsets.all(4),
+              child: firstTeamId.isNotEmpty
+                  ? Image.asset(
+                      TeamLogoService.getLogoPath(firstTeamId),
+                      fit: BoxFit.contain,
+                      errorBuilder: (_, __, ___) => Icon(
+                        Icons.sports_football,
+                        size: 18,
+                        color: brand,
+                      ),
+                    )
+                  : Icon(Icons.sports_football, size: 18, color: brand),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          cat,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 9,
+                            fontWeight: FontWeight.w800,
+                            letterSpacing: 1.2,
+                            color: categoryColor,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        '· $timeLabel',
+                        style: TextStyle(
+                          fontSize: 9,
+                          color: textMuted.withValues(alpha: 0.7),
+                          letterSpacing: 0.4,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    item.xPost,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      height: 1.35,
+                      letterSpacing: -0.15,
+                      color: textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 8, top: 4),
+              child: Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: textMuted.withValues(alpha: 0.6),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _timeAgo(DateTime dt) {
+    final d = DateTime.now().difference(dt.toLocal());
+    if (d.inMinutes < 60) return '${d.inMinutes}m';
+    if (d.inHours < 24) return '${d.inHours}h';
+    if (d.inDays < 7) return '${d.inDays}d';
+    return '${dt.month}/${dt.day}';
+  }
+}

--- a/flutter_app/lib/core/os_shell/widgets/news_feed/feed_navigation.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/feed_navigation.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../models/news_feed_item.dart';
+import '../../../services/articles_service.dart';
+import '../../../services/settings_service.dart';
+import '../../../../micro_apps/breaking_news/models/breaking_news_article.dart';
+import '../../../../micro_apps/breaking_news/views/breaking_news_detail_screen.dart';
+
+/// Push the breaking-news detail screen for a feed item. The detail screen
+/// fetches the full article from the articles project by ID; the summary
+/// supplies the placeholder content (headline, image, team) for the hero
+/// while the network request resolves.
+///
+/// The current app locale is baked into the detail fetcher so the request
+/// includes a `language` hint — sibling articles in the new API share a
+/// story across language-specific ids (e.g. id 229 = en, 230 = de), and we
+/// also forward the locale for any future server-side language fallback.
+Future<void> openNewsItemDetail(BuildContext context, NewsFeedItem item) {
+  final articles = ArticlesService();
+  final languageCode =
+      Provider.of<SettingsService>(context, listen: false).locale.languageCode;
+  return Navigator.of(context).push(
+    MaterialPageRoute(
+      builder: (_) => BreakingNewsDetailScreen(
+        summary: _toArticleSummary(item),
+        detailFetcher: (id) =>
+            articles.fetchArticleDetail(id, language: languageCode),
+        relatedFetcher: articles.fetchRelatedStories,
+      ),
+    ),
+  );
+}
+
+BreakingNewsArticle _toArticleSummary(NewsFeedItem item) {
+  return BreakingNewsArticle(
+    id: item.id,
+    headline: item.headline ?? item.xPost,
+    status: item.status,
+    imageUrl: item.imageUrl,
+    createdAt: item.createdAt,
+    teams: item.teams
+        ?.whereType<Map>()
+        .map((t) => TeamReference.fromJson(Map<String, dynamic>.from(t)))
+        .toList(),
+    players: item.players
+        ?.whereType<Map>()
+        .map((p) => PlayerReference.fromJson(Map<String, dynamic>.from(p)))
+        .toList(),
+    sourceName: item.source,
+  );
+}

--- a/flutter_app/lib/core/os_shell/widgets/news_feed/news_feed_widget.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/news_feed_widget.dart
@@ -1,21 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:provider/provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../controllers/news_feed_controller.dart';
 import '../../../models/news_feed_item.dart';
+import '../../../services/articles_service.dart';
 import '../../../services/settings_service.dart';
 import 'news_feed_item_card.dart';
 import 'video_feed_item_card.dart';
 import 'personalized_feed_item_card.dart';
 import 'deep_dive_feed_item_card.dart';
+import 'breaking_featured_card.dart';
+import 'breaking_list_item_card.dart';
 import '../../../widgets/shimmer_skeleton.dart';
 
 /// News feed widget with infinite scroll for the home screen
 class NewsFeedWidget extends StatefulWidget {
-  final SupabaseClient? supabaseClient;
+  /// Optional override (used by tests) for the articles backend.
+  final ArticlesService? articlesService;
 
-  const NewsFeedWidget({super.key, this.supabaseClient});
+  const NewsFeedWidget({super.key, this.articlesService});
 
   @override
   State<NewsFeedWidget> createState() => _NewsFeedWidgetState();
@@ -35,7 +38,7 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
   void _initializeController(SettingsService settings) {
     _controller = NewsFeedController(
       languageCode: settings.locale.languageCode,
-      client: widget.supabaseClient,
+      articlesService: widget.articlesService,
     );
     _precachedUrls.clear();
     _controller.loadInitial();
@@ -175,35 +178,18 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
           );
         }
 
+        // Index of the first NewsFeedItem (used as the featured hero card).
+        final featuredIndex =
+            _controller.items.indexWhere((it) => it is NewsFeedItem);
+        final lastIndex = _controller.items.length - 1;
+
         return SliverMainAxisGroup(
           slivers: [
-            // Team Logo Watermark Section - No Text
-            SliverToBoxAdapter(
-              child: SizedBox(
-                height: 100,
-                child: settings.selectedTeam != null
-                    ? Center(
-                        child: Opacity(
-                          opacity: 0.15,
-                          child: Image.asset(
-                            settings.selectedTeam!.logoUrl,
-                            width: 180,
-                            height: 180,
-                            fit: BoxFit.contain,
-                            errorBuilder: (c, e, s) => const SizedBox(),
-                          ),
-                        ),
-                      )
-                    : const SizedBox(),
-              ),
-            ),
-
-            // Feed Items
+            const SliverToBoxAdapter(child: SizedBox(height: 8)),
             SliverList(
               delegate: SliverChildBuilderDelegate(
                 (context, index) {
                   if (index >= _controller.items.length) {
-                    // Loading indicator at the end
                     if (_controller.hasMore) {
                       return const NewsFeedItemSkeleton();
                     }
@@ -211,19 +197,27 @@ class _NewsFeedWidgetState extends State<NewsFeedWidget> {
                   }
 
                   final item = _controller.items[index];
-
-                  // Pre-cache images for upcoming items (look-ahead of 3)
                   _precacheUpcomingImages(context, index);
 
-                  // Handle different feed item types
+                  if (item is NewsFeedItem) {
+                    if (index == featuredIndex) {
+                      return BreakingFeaturedCard(item: item);
+                    }
+                    return BreakingListItemCard(
+                      item: item,
+                      isLast: index == lastIndex && !_controller.hasMore,
+                    );
+                  }
+
+                  // Fallback rendering for other content types (kept for
+                  // forward-compat; gated micro-apps don't surface in MVP).
                   return switch (item) {
                     NewsFeedItem newsItem => NewsFeedItemCard(
                         item: newsItem,
                         userTeamId: userTeamId,
                       ),
-                    VideoFeedItem videoItem => VideoFeedItemCard(
-                        item: videoItem,
-                      ),
+                    VideoFeedItem videoItem =>
+                      VideoFeedItemCard(item: videoItem),
                     PersonalizedFeedItem personalizedItem =>
                       PersonalizedFeedItemCard(item: personalizedItem),
                     DeepDiveFeedItem deepDiveItem =>

--- a/flutter_app/lib/core/os_shell/widgets/t4l_floating_nav_bar.dart
+++ b/flutter_app/lib/core/os_shell/widgets/t4l_floating_nav_bar.dart
@@ -7,13 +7,11 @@ import '../../widgets/notification_badge.dart';
 class T4LFloatingNavBar extends StatefulWidget {
   final VoidCallback onHome;
   final VoidCallback onGameCenter;
-  final VoidCallback onHistory;
   final VoidCallback onSettings;
   final VoidCallback onTeamLogo;
   final String? favoriteTeamLogoUrl;
   final String? homeTooltip;
   final String? gameCenterTooltip;
-  final String? historyTooltip;
   final String? settingsTooltip;
   final bool showGameCenterBadge;
 
@@ -21,13 +19,11 @@ class T4LFloatingNavBar extends StatefulWidget {
     super.key,
     required this.onHome,
     required this.onGameCenter,
-    required this.onHistory,
     required this.onSettings,
     required this.onTeamLogo,
     this.favoriteTeamLogoUrl,
     this.homeTooltip,
     this.gameCenterTooltip,
-    this.historyTooltip,
     this.settingsTooltip,
     this.showGameCenterBadge = false,
   });
@@ -140,17 +136,10 @@ class _T4LFloatingNavBarState extends State<T4LFloatingNavBar>
                 ],
               ),
 
-              // Slot 3: Spacer for the Center Button
+              // Slot 3: Spacer for the Center Button (Team Logo / Team Center)
               const SizedBox(width: 60),
 
-              // Slot 4: History
-              _NavBarButton(
-                onTap: widget.onHistory,
-                tooltip: widget.historyTooltip,
-                svgAsset: 'assets/icons/back.svg',
-              ),
-
-              // Slot 5: Settings
+              // Slot 4: Settings
               _NavBarButton(
                 onTap: widget.onSettings,
                 tooltip: widget.settingsTooltip,

--- a/flutter_app/lib/core/os_shell/widgets/t4l_floating_nav_bar.dart
+++ b/flutter_app/lib/core/os_shell/widgets/t4l_floating_nav_bar.dart
@@ -4,6 +4,11 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tackle4loss_mobile/design_tokens.dart';
 import '../../widgets/notification_badge.dart';
 
+/// Floating dock — V3 design (segmented pill with badge floating above).
+///
+/// Three labelled buttons (Home / Schedule / Settings) inside a glass pill,
+/// with the team badge resting above the dock and overlapping its top edge
+/// by 10px. Inspired by `components-floating-dock.html` V3.
 class T4LFloatingNavBar extends StatefulWidget {
   final VoidCallback onHome;
   final VoidCallback onGameCenter;
@@ -14,6 +19,9 @@ class T4LFloatingNavBar extends StatefulWidget {
   final String? gameCenterTooltip;
   final String? settingsTooltip;
   final bool showGameCenterBadge;
+
+  /// Which dock tab is currently active. Defaults to home.
+  final T4LNavTab activeTab;
 
   const T4LFloatingNavBar({
     super.key,
@@ -26,33 +34,29 @@ class T4LFloatingNavBar extends StatefulWidget {
     this.gameCenterTooltip,
     this.settingsTooltip,
     this.showGameCenterBadge = false,
+    this.activeTab = T4LNavTab.home,
   });
 
   @override
   State<T4LFloatingNavBar> createState() => _T4LFloatingNavBarState();
 }
 
+enum T4LNavTab { home, schedule, settings }
+
 class _T4LFloatingNavBarState extends State<T4LFloatingNavBar>
     with SingleTickerProviderStateMixin {
-  late AnimationController _controller;
-  late Animation<double> _animation;
+  late final AnimationController _pulseController = AnimationController(
+    duration: const Duration(seconds: 2),
+    vsync: this,
+  )..repeat(reverse: true);
 
-  @override
-  void initState() {
-    super.initState();
-    _controller = AnimationController(
-      duration: const Duration(seconds: 2),
-      vsync: this,
-    )..repeat(reverse: true);
-    _animation = Tween<double>(
-      begin: 1.0,
-      end: 1.25,
-    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
-  }
+  static const double _badgeSize = 54;
+  static const double _badgeOverlap = 10;
+  static const double _dockHeight = 58;
 
   @override
   void dispose() {
-    _controller.dispose();
+    _pulseController.dispose();
     super.dispose();
   }
 
@@ -60,201 +64,251 @@ class _T4LFloatingNavBarState extends State<T4LFloatingNavBar>
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    // Adaptive glass colors
+    final activeColor = isDark ? const Color(0xFF4ADE80) : AppColors.brandBase;
+    final inactiveIcon =
+        isDark ? const Color(0xFFA1A1AA) : const Color(0xFF555555);
+    final inactiveLabel =
+        isDark ? const Color(0xFF71717A) : const Color(0xFF888888);
+
     final glassColor = isDark
-        ? Colors.white.withValues(alpha: 0.08)
-        : Colors.white.withValues(alpha: 0.6);
-
+        ? const Color(0xFF1A1C1C).withValues(alpha: 0.82)
+        : Colors.white.withValues(alpha: 0.72);
     final borderColor = isDark
-        ? Colors.white.withValues(alpha: 0.12)
-        : Colors.white.withValues(alpha: 0.4);
+        ? Colors.white.withValues(alpha: 0.08)
+        : Colors.white.withValues(alpha: 0.9);
+    final dividerColor = isDark
+        ? Colors.white.withValues(alpha: 0.08)
+        : Colors.black.withValues(alpha: 0.08);
+    final activeBg = isDark
+        ? const Color(0xFF4ADE80).withValues(alpha: 0.12)
+        : AppColors.brandBase.withValues(alpha: 0.10);
 
-    final shadowColor = isDark
-        ? Colors.black.withValues(alpha: 0.3)
-        : Colors.black.withValues(alpha: 0.1);
-
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-      height: 64,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          // 1. Bar Background with Glassmorphism
-          Positioned.fill(
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(20),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: glassColor,
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(
-                      color: borderColor,
-                      width: 1,
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+      child: SizedBox(
+        // Pill height + badge protrusion above the pill.
+        height: _dockHeight + (_badgeSize - _badgeOverlap),
+        child: Stack(
+          clipBehavior: Clip.none,
+          alignment: Alignment.bottomCenter,
+          children: [
+            // ─── Pill dock ──────────────────────────────────────────
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: _dockHeight,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(9999),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: glassColor,
+                      borderRadius: BorderRadius.circular(9999),
+                      border: Border.all(color: borderColor, width: 1),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black
+                              .withValues(alpha: isDark ? 0.35 : 0.13),
+                          blurRadius: 28,
+                          offset: const Offset(0, 8),
+                        ),
+                        BoxShadow(
+                          color: Colors.black
+                              .withValues(alpha: isDark ? 0.2 : 0.07),
+                          blurRadius: 6,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
                     ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: shadowColor,
-                        blurRadius: 20,
-                        offset: const Offset(0, 8),
-                      ),
-                    ],
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: _NavButton(
+                            tooltip: widget.homeTooltip,
+                            label: 'Home',
+                            svgAsset: 'assets/icons/home.svg',
+                            onTap: widget.onHome,
+                            active: widget.activeTab == T4LNavTab.home,
+                            activeColor: activeColor,
+                            inactiveIcon: inactiveIcon,
+                            inactiveLabel: inactiveLabel,
+                            activeBg: activeBg,
+                          ),
+                        ),
+                        _Divider(color: dividerColor),
+                        Expanded(
+                          child: Stack(
+                            clipBehavior: Clip.none,
+                            fit: StackFit.expand,
+                            alignment: Alignment.center,
+                            children: [
+                              _NavButton(
+                                tooltip: widget.gameCenterTooltip,
+                                label: 'Schedule',
+                                svgAsset: 'assets/icons/schedule.svg',
+                                onTap: widget.onGameCenter,
+                                active: widget.activeTab == T4LNavTab.schedule,
+                                activeColor: activeColor,
+                                inactiveIcon: inactiveIcon,
+                                inactiveLabel: inactiveLabel,
+                                activeBg: activeBg,
+                              ),
+                              if (widget.showGameCenterBadge)
+                                Positioned(
+                                  top: 4,
+                                  right: 8,
+                                  child: NotificationBadge(
+                                      show: widget.showGameCenterBadge),
+                                ),
+                            ],
+                          ),
+                        ),
+                        _Divider(color: dividerColor),
+                        Expanded(
+                          child: _NavButton(
+                            tooltip: widget.settingsTooltip,
+                            label: 'Settings',
+                            svgAsset: 'assets/icons/settings.svg',
+                            onTap: widget.onSettings,
+                            active: widget.activeTab == T4LNavTab.settings,
+                            activeColor: activeColor,
+                            inactiveIcon: inactiveIcon,
+                            inactiveLabel: inactiveLabel,
+                            activeBg: activeBg,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),
             ),
-          ),
 
-          // 2. Navigation Items
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              // Slot 1: Home (H)
-              _NavBarButton(
-                onTap: widget.onHome,
-                tooltip: widget.homeTooltip,
-                svgAsset: 'assets/icons/home.svg',
-              ),
-
-              // Slot 2: Game Center with optional badge
-              Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  _NavBarButton(
-                    onTap: widget.onGameCenter,
-                    tooltip: widget.gameCenterTooltip,
-                    svgAsset: 'assets/icons/schedule.svg',
-                  ),
-                  if (widget.showGameCenterBadge)
-                    Positioned(
-                      top: 4,
-                      right: 4,
-                      child:
-                          NotificationBadge(show: widget.showGameCenterBadge),
-                    ),
-                ],
-              ),
-
-              // Slot 3: Spacer for the Center Button (Team Logo / Team Center)
-              const SizedBox(width: 60),
-
-              // Slot 4: Settings
-              _NavBarButton(
-                onTap: widget.onSettings,
-                tooltip: widget.settingsTooltip,
-                svgAsset: 'assets/icons/settings.svg',
-              ),
-            ],
-          ),
-
-          // 3. Center Pop-out Button
-          Positioned(
-            top: -24,
-            left: 0,
-            right: 0,
-            child: Center(
+            // ─── Team badge floating above ──────────────────────────
+            Positioned(
+              top: 0,
               child: GestureDetector(
                 onTap: widget.onTeamLogo,
+                behavior: HitTestBehavior.opaque,
                 child: AnimatedBuilder(
-                  animation: _animation,
+                  animation: _pulseController,
                   builder: (context, child) {
                     final scale = widget.favoriteTeamLogoUrl == null
-                        ? _animation.value
+                        ? 1.0 + 0.06 * _pulseController.value
                         : 1.0;
-                    return Transform.scale(
-                      scale: scale,
-                      child: Container(
-                        width: 64,
-                        height: 64,
-                        padding: const EdgeInsets.all(4),
-                        decoration: BoxDecoration(
-                          color: AppColors.background,
-                          borderRadius: BorderRadius.circular(20),
-                          border: Border.all(
-                            color: widget.favoriteTeamLogoUrl != null
-                                ? AppColors.primary
-                                : Colors.white24,
-                            width: 3,
-                          ),
-                          boxShadow: [
-                            if (widget.favoriteTeamLogoUrl == null)
-                              BoxShadow(
-                                color: AppColors.primary.withValues(
-                                  alpha: 0.3 * (_controller.value),
-                                ),
-                                blurRadius: 15,
-                                spreadRadius: 5 * (_controller.value),
-                              ),
-                            ...AppShadows.md,
-                          ],
-                        ),
-                        child: child,
-                      ),
-                    );
+                    return Transform.scale(scale: scale, child: child);
                   },
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(16),
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: widget.favoriteTeamLogoUrl != null
-                          ? Image.asset(
-                              widget.favoriteTeamLogoUrl!,
-                              fit: BoxFit.contain,
-                            )
-                          : Image.asset(
-                              'assets/logos/nfl_logo.png',
-                              fit: BoxFit.contain,
-                            ),
+                  child: Container(
+                    width: _badgeSize,
+                    height: _badgeSize,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(17),
+                      border: Border.all(color: activeColor, width: 3),
+                      boxShadow: [
+                        BoxShadow(
+                          color: isDark
+                              ? Colors.black.withValues(alpha: 0.5)
+                              : AppColors.brandBase.withValues(alpha: 0.30),
+                          blurRadius: 28,
+                          offset: const Offset(0, 10),
+                        ),
+                      ],
+                    ),
+                    padding: const EdgeInsets.all(5),
+                    clipBehavior: Clip.antiAlias,
+                    child: Image.asset(
+                      widget.favoriteTeamLogoUrl ?? 'assets/logos/nfl_logo.png',
+                      fit: BoxFit.contain,
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
 }
 
-class _NavBarButton extends StatelessWidget {
-  final VoidCallback onTap;
-  final String? svgAsset;
+class _NavButton extends StatelessWidget {
   final String? tooltip;
+  final String label;
+  final String svgAsset;
+  final VoidCallback onTap;
+  final bool active;
+  final Color activeColor;
+  final Color inactiveIcon;
+  final Color inactiveLabel;
+  final Color activeBg;
 
-  const _NavBarButton({
+  const _NavButton({
+    required this.tooltip,
+    required this.label,
+    required this.svgAsset,
     required this.onTap,
-    this.svgAsset,
-    this.tooltip,
+    required this.active,
+    required this.activeColor,
+    required this.inactiveIcon,
+    required this.inactiveLabel,
+    required this.activeBg,
   });
 
   @override
   Widget build(BuildContext context) {
+    final iconColor = active ? activeColor : inactiveIcon;
+    final labelColor = active ? activeColor : inactiveLabel;
+
     return Tooltip(
-      message: tooltip ?? '',
+      message: tooltip ?? label,
       child: GestureDetector(
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Container(
-          width: 48,
-          height: 48,
-          alignment: Alignment.center,
-          child: svgAsset != null
-              ? SvgPicture.asset(
-                  svgAsset!,
-                  width: 24,
-                  height: 24,
-                  colorFilter: Theme.of(context).brightness == Brightness.dark
-                      ? ColorFilter.mode(
-                          Colors.white.withValues(alpha: 0.9),
-                          BlendMode.srcIn,
-                        )
-                      : null,
-                )
-              : const SizedBox.shrink(),
+          height: 44,
+          margin: const EdgeInsets.symmetric(vertical: 7, horizontal: 2),
+          decoration: BoxDecoration(
+            color: active ? activeBg : Colors.transparent,
+            borderRadius: BorderRadius.circular(9999),
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SvgPicture.asset(
+                svgAsset,
+                width: 20,
+                height: 20,
+                colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+              ),
+              const SizedBox(height: 3),
+              Text(
+                label.toUpperCase(),
+                style: TextStyle(
+                  fontSize: 9,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.27,
+                  color: labelColor,
+                  height: 1.0,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  final Color color;
+  const _Divider({required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(width: 1, height: 28, color: color);
   }
 }

--- a/flutter_app/lib/core/os_shell/widgets/t4l_scaffold.dart
+++ b/flutter_app/lib/core/os_shell/widgets/t4l_scaffold.dart
@@ -123,8 +123,6 @@ class T4LScaffold extends StatelessWidget {
                           homeTooltip: AppLocalizations.of(context)!.navHome,
                           gameCenterTooltip:
                               AppLocalizations.of(context)!.navGameCenter,
-                          historyTooltip:
-                              AppLocalizations.of(context)!.navHistory,
                           settingsTooltip:
                               AppLocalizations.of(context)!.navSettings,
                           favoriteTeamLogoUrl: settings.selectedTeam?.logoUrl,
@@ -133,8 +131,6 @@ class T4LScaffold extends StatelessWidget {
                           onGameCenter: () {
                             NavigationService().openGameCenter(context);
                           },
-                          onHistory: () =>
-                              NavigationService().reopenLastApp(context),
                           onSettings: () {
                             NavigationService().openSettings(
                               context,

--- a/flutter_app/lib/core/services/articles_service.dart
+++ b/flutter_app/lib/core/services/articles_service.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/news_feed_item.dart';
+import '../../micro_apps/breaking_news/models/breaking_news_article.dart';
+
+/// Cursor returned by `get-articles` for keyset pagination.
+class ArticlesCursor {
+  final String createdAt;
+  final int id;
+
+  const ArticlesCursor({required this.createdAt, required this.id});
+
+  Map<String, dynamic> toJson() => {'created_at': createdAt, 'id': id};
+}
+
+class ArticlesPage {
+  final List<NewsFeedItem> items;
+  final ArticlesCursor? nextCursor;
+
+  const ArticlesPage({required this.items, this.nextCursor});
+}
+
+/// Service for the dedicated "articles" Supabase project that owns the
+/// `get-articles` (home feed) and `get-article-detail` edge functions.
+///
+/// This project is separate from the main app project (auth, standings,
+/// realtime, etc.), so the service holds its own [SupabaseClient] keyed by
+/// the `ARTICLES_SUPABASE_URL` / `ARTICLES_SUPABASE_ANON_KEY` env entries.
+class ArticlesService {
+  final SupabaseClient _client;
+
+  ArticlesService({SupabaseClient? client})
+      : _client = client ?? _defaultClient();
+
+  static SupabaseClient _defaultClient() {
+    final url = dotenv.env['ARTICLES_SUPABASE_URL'];
+    final key = dotenv.env['ARTICLES_SUPABASE_ANON_KEY'];
+    if (url == null || url.isEmpty || key == null || key.isEmpty) {
+      throw StateError(
+        'Missing ARTICLES_SUPABASE_URL / ARTICLES_SUPABASE_ANON_KEY in .env',
+      );
+    }
+    return SupabaseClient(url, key);
+  }
+
+  /// Map app-internal language code (`en`, `de`) to the API's full BCP-47 tag.
+  static String mapLanguage(String code) {
+    switch (code.toLowerCase()) {
+      case 'de':
+        return 'de-DE';
+      case 'en':
+      default:
+        return 'en-US';
+    }
+  }
+
+  Future<ArticlesPage> fetchArticles({
+    required String language,
+    int limit = 20,
+    ArticlesCursor? cursor,
+  }) async {
+    final body = <String, dynamic>{
+      'limit': limit,
+      'language': mapLanguage(language),
+    };
+    if (cursor != null) body['cursor'] = cursor.toJson();
+
+    final response = await _client.functions.invoke(
+      'get-articles',
+      body: body,
+    );
+    if (response.status != 200) {
+      throw Exception('get-articles failed: HTTP ${response.status}');
+    }
+
+    final data = response.data as Map<String, dynamic>;
+    final items = (data['items'] as List<dynamic>? ?? const [])
+        .whereType<Map>()
+        .map((m) => _itemFromList(Map<String, dynamic>.from(m)))
+        .toList();
+    final next = data['next_cursor'];
+    final nextCursor = (next is Map)
+        ? ArticlesCursor(
+            createdAt: next['created_at'] as String,
+            id: (next['id'] as num).toInt(),
+          )
+        : null;
+    return ArticlesPage(items: items, nextCursor: nextCursor);
+  }
+
+  Future<BreakingNewsArticle> fetchArticleDetail(
+    String id, {
+    String? language,
+  }) async {
+    final intId = int.tryParse(id);
+    if (intId == null) {
+      throw ArgumentError('Article id must be numeric: $id');
+    }
+    final body = <String, dynamic>{'id': intId};
+    if (language != null && language.isNotEmpty) {
+      body['language'] = mapLanguage(language);
+    }
+    final response = await _client.functions.invoke(
+      'get-article-detail',
+      body: body,
+    );
+    if (response.status != 200) {
+      throw Exception('get-article-detail failed: HTTP ${response.status}');
+    }
+    return _articleFromDetail(response.data as Map<String, dynamic>);
+  }
+
+  /// Related stories aren't exposed by the new project; surface an empty list
+  /// so the detail screen renders cleanly without that section.
+  Future<List<RelatedStory>> fetchRelatedStories(
+    String id, {
+    String languageCode = 'en',
+  }) async {
+    return const [];
+  }
+
+  // ─── Mapping ──────────────────────────────────────────────────────────
+
+  static NewsFeedItem _itemFromList(Map<String, dynamic> json) {
+    final id = json['id'].toString();
+    final team = (json['team'] as String?)?.toLowerCase();
+    final teams = team != null && team.isNotEmpty
+        ? [
+            {'team_id': team}
+          ]
+        : null;
+    return NewsFeedItem(
+      id: id,
+      headline: json['headline'] as String?,
+      xPost: (json['introduction'] as String?) ?? '',
+      imageUrl: json['image'] as String?,
+      source: json['author'] as String?,
+      teams: teams,
+      players: null,
+      status: null,
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+  }
+
+  static BreakingNewsArticle _articleFromDetail(Map<String, dynamic> json) {
+    final id = json['id'].toString();
+    final team = (json['team'] as String?)?.toLowerCase();
+    final teams =
+        team != null && team.isNotEmpty ? [TeamReference(teamId: team)] : null;
+
+    final mentioned = (json['mentioned_players'] as List<dynamic>? ?? const [])
+        .whereType<Map>()
+        .map((m) => PlayerReference(
+              headshotUrl: m['headshot'] as String?,
+              name: m['display_name'] as String?,
+              id: m['player_id']?.toString(),
+            ))
+        .toList();
+
+    final sources =
+        (json['sources'] as List<dynamic>? ?? const []).whereType<Map>();
+    final firstSource = sources.isEmpty ? null : sources.first;
+
+    return BreakingNewsArticle(
+      id: id,
+      headline: json['headline'] as String? ?? '',
+      status: null,
+      subHeader: json['sub_headline'] as String?,
+      introductionParagraph: json['introduction'] as String?,
+      content: json['content'] as String?,
+      imageUrl: json['image'] as String?,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      teams: teams,
+      players: mentioned.isEmpty ? null : mentioned,
+      sourceUrl: firstSource?['url'] as String?,
+      sourceName: firstSource?['name'] as String?,
+    );
+  }
+}

--- a/flutter_app/lib/core/services/feature_flag_service.dart
+++ b/flutter_app/lib/core/services/feature_flag_service.dart
@@ -9,14 +9,15 @@ class FeatureFlagService {
   /// Key: Feature ID (usually matching app ID)
   /// Value: Enabled status
   final Map<String, bool> _flags = {
-    // Core apps
-    'app_hub': true,
+    // MVP scope: only breaking_news (home feed data) and standings are visible.
+    // Other apps remain in the repo but are flag-off for first App Store release.
+    'app_hub': false,
     'breaking_news': true,
-    'deep_dive': true,
-    'radio': true,
+    'deep_dive': false,
+    'radio': false,
     'standings': true,
-    'game_reports': false, // in development
-    'player_wordle': true, // Ready for testing
+    'game_reports': false,
+    'player_wordle': false,
   };
 
   /// Returns true if the feature/app is enabled.

--- a/flutter_app/lib/core/services/settings_service.dart
+++ b/flutter_app/lib/core/services/settings_service.dart
@@ -10,8 +10,7 @@ class SettingsService with ChangeNotifier {
   factory SettingsService() => _instance;
   SettingsService._internal() {
     _initLocale();
-    _loadPersistedTeam();
-    _loadPersistedTheme();
+    _bootstrap();
   }
 
   @visibleForTesting
@@ -20,14 +19,42 @@ class SettingsService with ChangeNotifier {
   Locale _locale = const Locale('en');
   Team? _selectedTeam;
   ThemeMode _themeMode = ThemeMode.light;
+  bool _onboardingComplete = false;
+  bool _isLoaded = false;
 
   static const String _teamKey = 'selected_team_id';
   static const String _themeKey = 'theme_mode';
+  static const String _onboardingKey = 'onboarding_complete_v1';
 
   Locale get locale => _locale;
   Team? get selectedTeam => _selectedTeam;
   ThemeMode get themeMode => _themeMode;
   bool get isDarkMode => _themeMode == ThemeMode.dark;
+
+  /// True once persisted preferences have been loaded from disk.
+  /// While false, callers should render a splash, not the home screen.
+  bool get isLoaded => _isLoaded;
+
+  /// True if the user has completed the forced first-launch onboarding
+  /// (team + language confirmation). Persists across launches.
+  bool get onboardingComplete => _onboardingComplete;
+
+  Future<void> _bootstrap() async {
+    final prefs = await SharedPreferences.getInstance();
+    await _loadPersistedTeam(prefs);
+    await _loadPersistedTheme(prefs);
+    _onboardingComplete = prefs.getBool(_onboardingKey) ?? false;
+    _isLoaded = true;
+    notifyListeners();
+  }
+
+  Future<void> markOnboardingComplete() async {
+    if (_onboardingComplete) return;
+    _onboardingComplete = true;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_onboardingKey, true);
+  }
 
   // Immersive Background Logic
   LinearGradient get backgroundGradient {
@@ -99,8 +126,7 @@ class SettingsService with ChangeNotifier {
     }
   }
 
-  Future<void> _loadPersistedTeam() async {
-    final prefs = await SharedPreferences.getInstance();
+  Future<void> _loadPersistedTeam(SharedPreferences prefs) async {
     final teamId = prefs.getString(_teamKey);
     if (teamId != null) {
       final teams = TeamService().getTeams();
@@ -109,7 +135,6 @@ class SettingsService with ChangeNotifier {
         orElse: () => teams.first,
       );
       _selectedTeam = team;
-      notifyListeners();
     }
   }
 
@@ -123,12 +148,10 @@ class SettingsService with ChangeNotifier {
     }
   }
 
-  Future<void> _loadPersistedTheme() async {
-    final prefs = await SharedPreferences.getInstance();
+  Future<void> _loadPersistedTheme(SharedPreferences prefs) async {
     final themeIndex = prefs.getInt(_themeKey);
     if (themeIndex != null) {
       _themeMode = ThemeMode.values[themeIndex];
-      notifyListeners();
     }
   }
 

--- a/flutter_app/lib/core/team_center/views/team_center_overlay.dart
+++ b/flutter_app/lib/core/team_center/views/team_center_overlay.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/team_model.dart';
 import '../controllers/team_center_controller.dart';
-import 'widgets/games_timeline.dart';
 import 'widgets/daily_update_card.dart';
 import 'widgets/team_menu_button.dart';
 import '../../os_shell/widgets/mini_player.dart';
@@ -115,40 +114,14 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
                               child: CircularProgressIndicator());
                         }
 
-                        // Prepare games for timeline
-                        // We need past, last, next.
-                        // Controller provides allTeamGames, lastGame, nextGame.
-                        // Logic: 'Last' is played. 'Next' is upcoming. 'Past' is 'Last - 1'.
-                        // For now, simpler logic based on available props to not over-engineer before backend fix.
-
-                        // Hacky "Past Game" find for UI demo
-                        final games = controller.allTeamGames;
-                        final lastGame = controller.lastGame;
-                        var pastGameIndex = -1;
-                        if (lastGame != null) {
-                          pastGameIndex = games.indexOf(lastGame) - 1;
-                        }
-                        final pastGame =
-                            (pastGameIndex >= 0 && pastGameIndex < games.length)
-                                ? games[pastGameIndex]
-                                : null;
-
                         return SingleChildScrollView(
                           padding: const EdgeInsets.symmetric(horizontal: 24),
                           child: Column(
                             children: [
                               const SizedBox(height: 10),
 
-                              // Timeline
-                              GamesTimeline(
-                                pastGame: pastGame,
-                                lastGame: controller.lastGame,
-                                nextGame: controller.nextGame,
-                                teamColor: widget.team.primaryColor,
-                                teamId: widget.team.id,
-                              ),
-
-                              const SizedBox(height: 30),
+                              // MVP: Games Timeline removed from Team Center.
+                              // Roster, Depth Chart, and Injuries remain.
 
                               // Daily Update
                               DailyUpdateCard(

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -8,14 +8,8 @@ import 'core/theme/t4l_theme.dart'; // New Theme
 import 'core/os_shell/views/os_shell_view.dart';
 import 'core/app_registry.dart';
 import 'core/services/settings_service.dart';
-import 'micro_apps/app_store/app_store_app.dart';
-import 'micro_apps/deep_dive/deep_dive_app.dart';
 import 'micro_apps/breaking_news/breaking_news_app.dart';
-import 'micro_apps/radio/radio_app.dart';
 import 'micro_apps/standings/standings_app.dart';
-import 'micro_apps/game_reports/game_reports_app.dart';
-import 'micro_apps/player_wordle/player_wordle_app.dart';
-import 'micro_apps/radio/controllers/radio_controller.dart';
 
 import 'core/services/installed_apps_service.dart';
 import 'core/services/new_content_service.dart';
@@ -42,15 +36,10 @@ Future<void> main() async {
   );
 
   // 2. Register MicroApps
-  // In a real app we might load these dynamically or via reflection,
-  // but for now we register them manually on boot.
-  AppRegistry().register(AppHubApp());
-  AppRegistry().register(DeepDiveApp());
+  // MVP scope: only Breaking News (data layer for home feed) and Standings.
+  // Other MicroApps remain in repo but are not registered or initialized.
   AppRegistry().register(BreakingNewsApp());
-  AppRegistry().register(RadioApp());
   AppRegistry().register(StandingsApp());
-  AppRegistry().register(GameReportsApp());
-  AppRegistry().register(PlayerWordleApp());
 
   // 3. Initialize Services
   await InstalledAppsService().init();
@@ -62,16 +51,6 @@ Future<void> main() async {
       providers: [
         ChangeNotifierProvider(create: (_) => SettingsService()),
         ChangeNotifierProvider.value(value: InstalledAppsService()),
-        ChangeNotifierProxyProvider<SettingsService, RadioController>(
-          create: (context) => RadioController(
-            languageCode: Provider.of<SettingsService>(context, listen: false)
-                .locale
-                .languageCode,
-          ),
-          update: (context, settings, controller) {
-            return controller!..loadStations(settings.locale.languageCode);
-          },
-        ),
       ],
       child: const Tackle4LossApp(),
     ),

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -42,7 +42,8 @@ Future<void> main() async {
   AppRegistry().register(StandingsApp());
 
   // 3. Initialize Services
-  await InstalledAppsService().init();
+  // MVP: InstalledAppsService is not initialized — no AppStrip consumes it.
+  // Will be re-enabled when more MicroApps return to the visible surface.
   // AudioPlayerService is lazily initialized on first playback request
   await NewContentService().init(); // Initialize new content tracking
 

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_gemma/flutter_gemma.dart';
 import 'l10n/app_localizations.dart';
 import 'core/theme/t4l_theme.dart'; // New Theme
 import 'core/os_shell/views/os_shell_view.dart';
@@ -31,10 +30,9 @@ Future<void> main() async {
     anonKey: dotenv.env['SUPABASE_ANON_KEY']!,
   );
 
-  // Initialize FlutterGemma plugin
-  FlutterGemma.initialize(
-    maxDownloadRetries: 5,
-  );
+  // MVP: FlutterGemma is not initialized — Game Reports MicroApp (its only
+  // consumer) is flag-off. The flutter_gemma package is removed from pubspec
+  // to drop the TensorFlowLiteSelectTfOps iOS dependency from the binary.
 
   // 2. Register MicroApps
   // MVP scope: only Breaking News (data layer for home feed) and Standings.

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_gemma/flutter_gemma.dart';
 import 'l10n/app_localizations.dart';
 import 'core/theme/t4l_theme.dart'; // New Theme
 import 'core/os_shell/views/os_shell_view.dart';
+import 'core/onboarding/views/first_launch_flow.dart';
 import 'core/app_registry.dart';
 import 'core/services/settings_service.dart';
 import 'micro_apps/breaking_news/breaking_news_app.dart';
@@ -94,9 +95,32 @@ class Tackle4LossApp extends StatelessWidget {
           builder: (context, child) {
             return child!; // Application content
           },
-          home: const OSShellView(),
+          home: _RootGate(settings: settings),
         );
       },
     );
+  }
+}
+
+/// Decides whether to show a splash, the forced first-launch flow, or the
+/// OS Shell. SettingsService loads its persisted prefs asynchronously; we
+/// must not render the home screen before that completes, otherwise the
+/// onboarding flag is unknown.
+class _RootGate extends StatelessWidget {
+  final SettingsService settings;
+
+  const _RootGate({required this.settings});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!settings.isLoaded) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (!settings.onboardingComplete) {
+      return const FirstLaunchFlow();
+    }
+    return const OSShellView();
   }
 }

--- a/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
+++ b/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
@@ -1,23 +1,46 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
-import '../../../core/theme/t4l_theme.dart';
-import '../../../core/services/team_logo_service.dart';
-import '../../../core/services/settings_service.dart';
 import 'package:tackle4loss_mobile/design_tokens.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../../core/os_shell/widgets/app_dock.dart';
+import '../../../core/services/settings_service.dart';
+import '../../../core/services/team_logo_service.dart';
+import '../../../core/theme/t4l_theme.dart';
 import '../../../l10n/app_localizations.dart';
 import '../models/breaking_news_article.dart';
 import '../services/breaking_news_service.dart';
 import 'widgets/related_stories_section.dart';
 
+/// Article detail — implementation of the V3 "Article Detail" design.
+///
+/// Full-bleed hero image with parallax + dark gradient, floating back/share
+/// pills, italic Anton headline, byline bar with source/date/read-time, and
+/// a typographically-led body. Falls back gracefully while the full article
+/// content is still loading from Supabase.
+/// Async fetchers used by the detail screen. Defaults are wired to the legacy
+/// `BreakingNewsService`; the home-feed flow injects `ArticlesService`-backed
+/// fetchers so taps on home-feed cards resolve against the new articles
+/// project.
+typedef ArticleDetailFetcher = Future<BreakingNewsArticle> Function(String id);
+typedef RelatedStoriesFetcher = Future<List<RelatedStory>> Function(
+  String id, {
+  required String languageCode,
+});
+
 class BreakingNewsDetailScreen extends StatefulWidget {
   final BreakingNewsArticle summary;
+  final ArticleDetailFetcher? detailFetcher;
+  final RelatedStoriesFetcher? relatedFetcher;
 
   const BreakingNewsDetailScreen({
     super.key,
     required this.summary,
+    this.detailFetcher,
+    this.relatedFetcher,
   });
 
   @override
@@ -26,16 +49,26 @@ class BreakingNewsDetailScreen extends StatefulWidget {
 }
 
 class _BreakingNewsDetailScreenState extends State<BreakingNewsDetailScreen> {
-  final _service = BreakingNewsService();
+  final _legacyService = BreakingNewsService();
   late Future<BreakingNewsArticle> _detailFuture;
   late Future<List<RelatedStory>> _relatedFuture;
+
+  final _scrollController = ScrollController();
+  double _scrollY = 0;
+
+  static const double _heroHeight = 310;
+
+  ArticleDetailFetcher get _detailFetcher =>
+      widget.detailFetcher ?? _legacyService.fetchBreakingNewsDetail;
+  RelatedStoriesFetcher get _relatedFetcher =>
+      widget.relatedFetcher ?? _legacyService.fetchRelatedStories;
 
   @override
   void initState() {
     super.initState();
-    _detailFuture = _service.fetchBreakingNewsDetail(widget.summary.id);
-    // language_code will be set in didChangeDependencies when context is available
+    _detailFuture = _detailFetcher(widget.summary.id);
     _relatedFuture = Future.value([]);
+    _scrollController.addListener(_onScroll);
   }
 
   @override
@@ -44,386 +77,768 @@ class _BreakingNewsDetailScreenState extends State<BreakingNewsDetailScreen> {
     final languageCode = Provider.of<SettingsService>(context, listen: false)
         .locale
         .languageCode;
-    _relatedFuture = _service.fetchRelatedStories(
+    _relatedFuture = _relatedFetcher(
       widget.summary.id,
       languageCode: languageCode,
     );
   }
 
   @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    setState(() => _scrollY = _scrollController.offset);
+  }
+
+  double get _progress {
+    if (!_scrollController.hasClients) return 0;
+    final max = _scrollController.position.maxScrollExtent;
+    return max > 0 ? (_scrollController.offset / max).clamp(0.0, 1.0) : 0;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).extension<T4LThemeColors>()!;
-    // Use summary data initially, then upgrade to detail if loaded
+    final theme = Theme.of(context);
+    final colors = theme.extension<T4LThemeColors>()!;
+    final isDark = theme.brightness == Brightness.dark;
+    final settings = Provider.of<SettingsService>(context);
     final article = widget.summary;
 
-    // Access settings for background gradient
-    final settings = Provider.of<SettingsService>(context);
-
     return Scaffold(
-      backgroundColor: Colors.transparent, // Allow gradient to show
+      backgroundColor: Colors.transparent,
+      extendBody: true,
+      bottomNavigationBar: const AppDock(),
       body: Container(
-        decoration: BoxDecoration(
-          gradient: settings.backgroundGradient,
-        ),
-        child: CustomScrollView(
-          slivers: [
-            // 1. Sliver App Bar with Hero Image
-            SliverAppBar(
-              expandedHeight: 300,
-              pinned: true,
-              backgroundColor: colors.surface.withValues(
-                  alpha: 0.9), // Match surface but slightly translucent
-              leading: IconButton(
-                icon: Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.5),
-                    shape: BoxShape.circle,
+        decoration: BoxDecoration(gradient: settings.backgroundGradient),
+        child: Stack(
+          children: [
+            // Scrollable content
+            CustomScrollView(
+              controller: _scrollController,
+              slivers: [
+                SliverToBoxAdapter(
+                  child: _Hero(
+                    article: article,
+                    scrollY: _scrollY,
+                    height: _heroHeight,
                   ),
-                  child: const Icon(Icons.arrow_back,
-                      color: Colors.white, size: 20),
                 ),
-                onPressed: () => Navigator.of(context).pop(),
-              ),
-              flexibleSpace: FlexibleSpaceBar(
-                background: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    if (article.imageUrl != null)
-                      Hero(
-                        tag: 'breaking_news_hero_${article.id}',
-                        child: CachedNetworkImage(
-                          imageUrl: article.imageUrl!,
-                          fit: BoxFit.cover,
-                        ),
-                      ),
+                SliverToBoxAdapter(
+                  child: FutureBuilder<BreakingNewsArticle>(
+                    future: _detailFuture,
+                    builder: (context, snapshot) {
+                      final fullArticle = snapshot.data;
+                      final displayArticle = fullArticle ?? article;
+                      final isLoading =
+                          snapshot.connectionState == ConnectionState.waiting;
+                      final hasError = snapshot.hasError;
 
-                    // Gradient Overlay for text readability
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [
-                            Colors.black.withValues(alpha: 0.3),
-                            Colors.transparent,
-                          ],
-                          stops: const [0.0, 0.3],
-                        ),
-                      ),
-                    ),
+                      return _Body(
+                        article: displayArticle,
+                        fullArticle: fullArticle,
+                        isLoading: isLoading,
+                        hasError: hasError,
+                        relatedFuture: _relatedFuture,
+                        colors: colors,
+                        isDark: isDark,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
 
-                    // UPDATE badge (bottom-right of hero image)
-                    if (article.isUpdate)
-                      Positioned(
-                        bottom: 12,
-                        right: 12,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 5),
-                          decoration: BoxDecoration(
-                            color: AppColors.breakingNewsRed,
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: Text(
-                            AppLocalizations.of(context)!.breakingNewsUpdateTag,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 11,
-                              fontWeight: FontWeight.w900,
-                              letterSpacing: 1.0,
-                            ),
-                          ),
-                        ),
-                      ),
-                  ],
+            // Top reading-progress bar
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: SafeArea(
+                bottom: false,
+                child: Container(
+                  height: 2,
+                  color: colors.brand.withValues(alpha: 0.10),
+                  child: FractionallySizedBox(
+                    alignment: Alignment.centerLeft,
+                    widthFactor: _progress,
+                    child: Container(color: colors.brand),
+                  ),
                 ),
               ),
             ),
 
-            // 2. Content Body
-            SliverToBoxAdapter(
-              child: FutureBuilder<BreakingNewsArticle>(
-                future: _detailFuture,
-                builder: (context, snapshot) {
-                  // If we have full detail, use it. Otherwise use summary + loading indicator
-                  final fullArticle = snapshot.data;
-                  final displayArticle = fullArticle ?? article;
-                  final isLoading =
-                      snapshot.connectionState == ConnectionState.waiting;
-                  final hasError = snapshot.hasError;
-                  final sourceUri = displayArticle.sourceUrl != null
-                      ? Uri.tryParse(displayArticle.sourceUrl!)
-                      : null;
-                  final hasValidSourceUrl = sourceUri != null &&
-                      (sourceUri.isScheme('http') ||
-                          sourceUri.isScheme('https'));
-
-                  return Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Team & Source Meta
-                        Row(
+            // Floating back + share buttons
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: SafeArea(
+                bottom: false,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(14, 8, 14, 0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      _GlassPillButton(
+                        onTap: () => Navigator.of(context).pop(),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
                           children: [
-                            if (displayArticle.sourceName != 'Source') ...[
-                              // Make source clickable if URL exists
-                              InkWell(
-                                onTap: hasValidSourceUrl
-                                    ? () async {
-                                        if (await canLaunchUrl(sourceUri)) {
-                                          await launchUrl(
-                                            sourceUri,
-                                            mode:
-                                                LaunchMode.externalApplication,
-                                          );
-                                        }
-                                      }
-                                    : null,
-                                child: Container(
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 8, vertical: 4),
-                                  decoration: BoxDecoration(
-                                    color: Colors.white,
-                                    borderRadius: BorderRadius.circular(4),
-                                  ),
-                                  child: Text(
-                                    displayArticle.sourceName.toUpperCase(),
-                                    style: TextStyle(
-                                      color: colors.brand, // Use brand color
-                                      fontSize: 10,
-                                      fontWeight: FontWeight.w900,
-                                      letterSpacing: 1.0,
-                                      decoration: hasValidSourceUrl
-                                          ? TextDecoration.underline
-                                          : null,
-                                      decorationColor: colors.brand,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              Text(
-                                '•',
-                                style: TextStyle(
-                                    color: Colors.white.withValues(alpha: 0.7)),
-                              ),
-                              const SizedBox(width: 8),
-                            ],
+                            Icon(Icons.chevron_left,
+                                size: 18, color: colors.brand),
+                            const SizedBox(width: 2),
                             Text(
-                              DateFormat('MMM d, y • h:mm a')
-                                  .format(displayArticle.createdAt),
-                              style: TextStyle(
-                                color: colors.textSecondary,
-                                fontSize: 12,
-                                fontWeight: FontWeight.w500,
+                              MaterialLocalizations.of(context)
+                                  .backButtonTooltip,
+                              style: const TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w700,
+                                letterSpacing: -0.1,
+                                color: AppColors.neutralText,
                               ),
                             ),
                           ],
                         ),
-                        const SizedBox(height: 16),
-
-                        // Headline
-                        Text(
-                          displayArticle.headline,
-                          style: AppTextStyles.h2.copyWith(
-                            color: colors.textPrimary,
-                            fontSize: 24,
-                            height: 1.2,
-                          ),
-                        ),
-                        const SizedBox(height: 24),
-
-                        // Error Layer
-                        if (hasError)
-                          Container(
-                            padding: const EdgeInsets.all(16),
-                            decoration: BoxDecoration(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .error
-                                  .withValues(alpha: 0.1),
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            child: Row(
-                              children: [
-                                Icon(Icons.error_outline,
-                                    color: Theme.of(context).colorScheme.error),
-                                const SizedBox(width: 12),
-                                Expanded(
-                                  child: Text(
-                                    AppLocalizations.of(context)!
-                                        .breakingNewsDetailLoadError,
-                                    style: TextStyle(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .error),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-
-                        // Loading Layer
-                        if (isLoading)
-                          const Center(
-                            child: Padding(
-                              padding: EdgeInsets.all(32),
-                              child: CircularProgressIndicator(),
-                            ),
-                          ),
-
-                        // Full Content Layer
-                        if (fullArticle != null) ...[
-                          // Team Logos (if any)
-                          if (fullArticle.teams?.isNotEmpty == true) ...[
-                            Wrap(
-                              spacing: 12,
-                              runSpacing: 12,
-                              children: fullArticle.teams!.map((team) {
-                                final teamId = team.teamId.toLowerCase();
-                                return Chip(
-                                  avatar: Container(
-                                    decoration: const BoxDecoration(
-                                      color: Colors.white,
-                                      shape: BoxShape.circle,
-                                    ),
-                                    padding: const EdgeInsets.all(2),
-                                    child: CircleAvatar(
-                                      backgroundColor: Colors.white,
-                                      backgroundImage: AssetImage(
-                                        TeamLogoService.getLogoPath(teamId),
-                                      ),
-                                    ),
-                                  ),
-                                  label: Text(teamId.toUpperCase()),
-                                  backgroundColor: Theme.of(context)
-                                      .colorScheme
-                                      .surfaceContainerHighest,
-                                  side: BorderSide.none,
-                                  labelStyle: TextStyle(
-                                    color: colors.textPrimary,
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                );
-                              }).toList(),
-                            ),
-                            const SizedBox(height: 24),
-                          ],
-
-                          // Introduction
-                          if (fullArticle.introductionParagraph != null) ...[
-                            Text(
-                              fullArticle.introductionParagraph!,
-                              style: AppTextStyles.body.copyWith(
-                                color: colors.textPrimary,
-                                fontWeight: FontWeight.w600,
-                                fontSize: 18,
-                                height: 1.5,
-                              ),
-                            ),
-                            const SizedBox(height: 20),
-                          ],
-
-                          // Player Headshots
-                          if (fullArticle.players?.isNotEmpty == true) ...[
-                            SizedBox(
-                              height: 70,
-                              child: ListView.separated(
-                                scrollDirection: Axis.horizontal,
-                                itemCount: fullArticle.players!.length,
-                                separatorBuilder: (_, __) =>
-                                    const SizedBox(width: 16),
-                                itemBuilder: (context, index) {
-                                  final player = fullArticle.players![index];
-                                  final headshot = player.headshotUrl;
-                                  if (headshot == null) {
-                                    return const SizedBox.shrink();
-                                  }
-                                  return Column(
-                                    children: [
-                                      Container(
-                                        decoration: const BoxDecoration(
-                                          color: Colors.white,
-                                          shape: BoxShape.circle,
-                                        ),
-                                        padding: const EdgeInsets.all(
-                                            2), // White border effect
-                                        child: CircleAvatar(
-                                          radius: 24,
-                                          backgroundImage:
-                                              NetworkImage(headshot),
-                                          backgroundColor: Colors.white,
-                                        ),
-                                      ),
-                                      if (player.name != null) ...[
-                                        const SizedBox(height: 4),
-                                        Text(
-                                          player.name!,
-                                          style: TextStyle(
-                                            fontSize: 10,
-                                            color: colors.textSecondary,
-                                          ),
-                                        )
-                                      ]
-                                    ],
-                                  );
-                                },
-                              ),
-                            ),
-                            const SizedBox(height: 24),
-                          ],
-
-                          // Body Content
-                          if (fullArticle.content != null)
-                            Text(
-                              fullArticle.content!,
-                              style: AppTextStyles.body.copyWith(
-                                color: colors
-                                    .textSecondary, // Softer for reading long text
-                                fontSize: 16,
-                                height: 1.6,
-                              ),
-                            ),
-
-                          const SizedBox(height: 32),
-
-                          // Related Stories (Story Timeline)
-                          FutureBuilder<List<RelatedStory>>(
-                            future: _relatedFuture,
-                            builder: (context, relatedSnapshot) {
-                              final related = relatedSnapshot.data ?? [];
-                              if (related.isEmpty) {
-                                return const SizedBox.shrink();
-                              }
-                              return RelatedStoriesSection(
-                                relatedStories: related,
-                                currentArticle: fullArticle,
-                                onStoryTap: (story) {
-                                  Navigator.of(context).push(
-                                    MaterialPageRoute(
-                                      builder: (_) => BreakingNewsDetailScreen(
-                                        summary: story.toArticle(),
-                                      ),
-                                    ),
-                                  );
-                                },
-                              );
-                            },
-                          ),
-
-                          const SizedBox(height: 40),
-                        ],
-                      ],
-                    ),
-                  );
-                },
+                      ),
+                      _GlassIconButton(
+                        onTap: () => _share(article),
+                        icon: Icons.ios_share_outlined,
+                        iconColor: colors.brand,
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Future<void> _share(BreakingNewsArticle article) async {
+    final url = article.sourceUrl;
+    if (url == null) return;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}
+
+// ─── Hero ────────────────────────────────────────────────────────────
+
+class _Hero extends StatelessWidget {
+  final BreakingNewsArticle article;
+  final double scrollY;
+  final double height;
+
+  const _Hero({
+    required this.article,
+    required this.scrollY,
+    required this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final parallax = (scrollY * 0.35).clamp(0.0, 60.0);
+    final overlayOpacity = (0.55 + scrollY * 0.001).clamp(0.55, 0.88);
+
+    return SizedBox(
+      height: height,
+      child: ClipRect(
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            // Image + parallax
+            Transform.translate(
+              offset: Offset(0, parallax),
+              child: article.imageUrl != null
+                  ? Hero(
+                      tag: 'breaking_news_hero_${article.id}',
+                      child: CachedNetworkImage(
+                        imageUrl: article.imageUrl!,
+                        fit: BoxFit.cover,
+                        memCacheWidth: 900,
+                      ),
+                    )
+                  : Container(
+                      decoration: const BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                          colors: [
+                            Color(0xFF0D2119),
+                            Color(0xFF1A5F3D),
+                            Color(0xFF0A2F24),
+                          ],
+                        ),
+                      ),
+                    ),
+            ),
+
+            // Dark gradient overlay for text readability
+            DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.20),
+                    AppColors.brandBase.withValues(alpha: 0.50),
+                    const Color(0xFF0A1C12).withValues(alpha: overlayOpacity),
+                  ],
+                  stops: const [0.0, 0.55, 1.0],
+                ),
+              ),
+            ),
+
+            // Content (eyebrow + headline + subtitle)
+            Positioned(
+              left: 20,
+              right: 20,
+              bottom: 22,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Update vs. Breaking eyebrow pill
+                  if (article.isUpdate)
+                    _EyebrowPill(
+                      text: l10n.breakingNewsUpdateTag,
+                      bg: AppColors.breakingNewsRed,
+                      fg: Colors.white,
+                    )
+                  else
+                    _EyebrowPill(
+                      text: l10n.breakingNewsTag,
+                      bg: const Color(0xFFC9A256),
+                      fg: AppColors.brandBase,
+                    ),
+                  const SizedBox(height: 12),
+                  Text(
+                    article.headline.toUpperCase(),
+                    style: GoogleFonts.anton(
+                      fontSize: 32,
+                      height: 0.95,
+                      letterSpacing: -0.5,
+                      color: Colors.white,
+                      fontStyle: FontStyle.italic,
+                      shadows: const [
+                        Shadow(
+                          color: Color(0x66000000),
+                          blurRadius: 12,
+                          offset: Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if ((article.subHeader ?? '').isNotEmpty) ...[
+                    const SizedBox(height: 10),
+                    Text(
+                      article.subHeader!,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        height: 1.45,
+                        color: Color(0xB8FFFFFF),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EyebrowPill extends StatelessWidget {
+  final String text;
+  final Color bg;
+  final Color fg;
+  const _EyebrowPill({required this.text, required this.bg, required this.fg});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 9,
+          fontWeight: FontWeight.w800,
+          letterSpacing: 1.4,
+          color: fg,
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Glass header buttons ────────────────────────────────────────────
+
+class _GlassPillButton extends StatelessWidget {
+  final VoidCallback onTap;
+  final Widget child;
+  const _GlassPillButton({required this.onTap, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return _GlassSurface(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(10, 7, 13, 7),
+        child: child,
+      ),
+    );
+  }
+}
+
+class _GlassIconButton extends StatelessWidget {
+  final VoidCallback onTap;
+  final IconData icon;
+  final Color iconColor;
+  const _GlassIconButton({
+    required this.onTap,
+    required this.icon,
+    required this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _GlassSurface(
+      onTap: onTap,
+      child: SizedBox(
+        width: 36,
+        height: 36,
+        child: Icon(icon, size: 16, color: iconColor),
+      ),
+    );
+  }
+}
+
+class _GlassSurface extends StatelessWidget {
+  final VoidCallback onTap;
+  final Widget child;
+  const _GlassSurface({required this.onTap, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(11),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+        child: Material(
+          color: Colors.white.withValues(alpha: 0.92),
+          child: InkWell(
+            onTap: onTap,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                border: Border.all(
+                    color: AppColors.brandBase.withValues(alpha: 0.15),
+                    width: 1),
+                borderRadius: BorderRadius.circular(11),
+                boxShadow: const [
+                  BoxShadow(
+                      color: Color(0x1F000000),
+                      blurRadius: 8,
+                      offset: Offset(0, 2)),
+                ],
+              ),
+              child: Center(child: child),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Body ────────────────────────────────────────────────────────────
+
+class _Body extends StatelessWidget {
+  final BreakingNewsArticle article;
+  final BreakingNewsArticle? fullArticle;
+  final bool isLoading;
+  final bool hasError;
+  final Future<List<RelatedStory>> relatedFuture;
+  final T4LThemeColors colors;
+  final bool isDark;
+
+  const _Body({
+    required this.article,
+    required this.fullArticle,
+    required this.isLoading,
+    required this.hasError,
+    required this.relatedFuture,
+    required this.colors,
+    required this.isDark,
+  });
+
+  int _readMinutes(BreakingNewsArticle a) {
+    final words = (a.introductionParagraph ?? '').split(RegExp(r'\s+')).length +
+        (a.content ?? '').split(RegExp(r'\s+')).length;
+    final mins = (words / 220).ceil();
+    return mins.clamp(1, 60);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final fullForRead = fullArticle ?? article;
+    final readMins = _readMinutes(fullForRead);
+
+    return Container(
+      color: colors.surface,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _BylineBar(
+            article: article,
+            readMins: readMins,
+            colors: colors,
+            isDark: isDark,
+          ),
+          if (hasError)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .error
+                      .withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.error_outline,
+                        color: Theme.of(context).colorScheme.error),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        l10n.breakingNewsDetailLoadError,
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.error),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          if (isLoading)
+            const Padding(
+              padding: EdgeInsets.all(32),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          if (fullArticle != null) ...[
+            if (fullArticle!.introductionParagraph != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+                child: Text(
+                  fullArticle!.introductionParagraph!,
+                  style: TextStyle(
+                    fontSize: 16,
+                    height: 1.7,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: -0.1,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+            if ((fullArticle!.subHeader ?? '').isNotEmpty &&
+                fullArticle!.subHeader != article.subHeader)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 24, 20, 0),
+                child: Text(
+                  fullArticle!.subHeader!,
+                  style: TextStyle(
+                    fontFamily: AppTextStyles.fontHeading,
+                    fontSize: 18,
+                    height: 1.2,
+                    letterSpacing: -0.2,
+                    color: colors.textPrimary,
+                  ),
+                ),
+              ),
+            if (fullArticle!.teams?.isNotEmpty == true)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+                child: Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  children: fullArticle!.teams!.map((team) {
+                    final teamId = team.teamId.toLowerCase();
+                    return _TeamChip(
+                        teamId: teamId, colors: colors, isDark: isDark);
+                  }).toList(),
+                ),
+              ),
+            if (fullArticle!.players?.isNotEmpty == true)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+                child: SizedBox(
+                  height: 70,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: fullArticle!.players!.length,
+                    separatorBuilder: (_, __) => const SizedBox(width: 14),
+                    itemBuilder: (context, index) {
+                      final player = fullArticle!.players![index];
+                      final headshot = player.headshotUrl;
+                      if (headshot == null) return const SizedBox.shrink();
+                      return Column(
+                        children: [
+                          Container(
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: colors.brand.withValues(alpha: 0.30),
+                                width: 1.5,
+                              ),
+                            ),
+                            padding: const EdgeInsets.all(2),
+                            child: CircleAvatar(
+                              radius: 22,
+                              backgroundImage: NetworkImage(headshot),
+                              backgroundColor: Colors.white,
+                            ),
+                          ),
+                          if (player.name != null) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              player.name!,
+                              style: TextStyle(
+                                fontSize: 10,
+                                color: colors.textSecondary,
+                              ),
+                            ),
+                          ],
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              ),
+            if (fullArticle!.content != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 14, 20, 0),
+                child: Text(
+                  fullArticle!.content!,
+                  style: TextStyle(
+                    fontSize: 15,
+                    height: 1.75,
+                    color: colors.textSecondary,
+                  ),
+                ),
+              ),
+            const SizedBox(height: 32),
+            FutureBuilder<List<RelatedStory>>(
+              future: relatedFuture,
+              builder: (context, relatedSnapshot) {
+                final related = relatedSnapshot.data ?? [];
+                if (related.isEmpty) return const SizedBox.shrink();
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: RelatedStoriesSection(
+                    relatedStories: related,
+                    currentArticle: fullArticle!,
+                    onStoryTap: (story) {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => BreakingNewsDetailScreen(
+                            summary: story.toArticle(),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+            // Bottom clearance for the floating dock.
+            const SizedBox(height: 140),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _BylineBar extends StatelessWidget {
+  final BreakingNewsArticle article;
+  final int readMins;
+  final T4LThemeColors colors;
+  final bool isDark;
+
+  const _BylineBar({
+    required this.article,
+    required this.readMins,
+    required this.colors,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final sourceUri =
+        article.sourceUrl != null ? Uri.tryParse(article.sourceUrl!) : null;
+    final hasValidSourceUrl = sourceUri != null &&
+        (sourceUri.isScheme('http') || sourceUri.isScheme('https'));
+    final hasSource = article.sourceName != 'Source';
+    final dividerColor =
+        (isDark ? Colors.white : AppColors.brandBase).withValues(alpha: 0.10);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 14, 20, 14),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              if (hasSource)
+                Flexible(
+                  child: GestureDetector(
+                    onTap: hasValidSourceUrl
+                        ? () async {
+                            if (await canLaunchUrl(sourceUri)) {
+                              await launchUrl(sourceUri,
+                                  mode: LaunchMode.externalApplication);
+                            }
+                          }
+                        : null,
+                    child: Text(
+                      article.sourceName.toUpperCase(),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 1.0,
+                        color: colors.brand,
+                        decoration:
+                            hasValidSourceUrl ? TextDecoration.underline : null,
+                        decorationColor: colors.brand,
+                      ),
+                    ),
+                  ),
+                ),
+              if (hasSource) const SizedBox(width: 8),
+              if (hasSource)
+                Text('·',
+                    style: TextStyle(
+                        color: colors.textMuted.withValues(alpha: 0.6))),
+              if (hasSource) const SizedBox(width: 8),
+              Text(
+                DateFormat('MMM d, y · h:mm a').format(article.createdAt),
+                style: TextStyle(
+                  fontSize: 11,
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const Spacer(),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: colors.brand.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.access_time_rounded,
+                        size: 11, color: colors.brand),
+                    const SizedBox(width: 4),
+                    Text(
+                      '$readMins min',
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        color: colors.brand,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 14),
+            child: Container(height: 1, color: dividerColor),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TeamChip extends StatelessWidget {
+  final String teamId;
+  final T4LThemeColors colors;
+  final bool isDark;
+  const _TeamChip({
+    required this.teamId,
+    required this.colors,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bg =
+        isDark ? Colors.white.withValues(alpha: 0.06) : AppColors.neutralSoft;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(4, 4, 12, 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: colors.brand.withValues(alpha: 0.12)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 26,
+            height: 26,
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+            ),
+            padding: const EdgeInsets.all(2),
+            child: Image.asset(
+              TeamLogoService.getLogoPath(teamId),
+              fit: BoxFit.contain,
+              errorBuilder: (_, __, ___) =>
+                  Icon(Icons.sports_football, size: 14, color: colors.brand),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            teamId.toUpperCase(),
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0.6,
+              color: colors.textPrimary,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/flutter_app/lib/micro_apps/game_reports/services/function_gemma_service.dart
+++ b/flutter_app/lib/micro_apps/game_reports/services/function_gemma_service.dart
@@ -1,191 +1,59 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter_gemma/flutter_gemma.dart';
 
-/// Service responsible for managing the local FunctionGemma model.
-/// Handles initialization, model downloading/checking, and inference.
+/// MVP stub: the Game Reports MicroApp is flag-off and the `flutter_gemma`
+/// package has been removed from pubspec to drop the TensorFlowLiteSelectTfOps
+/// iOS dependency. The public API surface is preserved so
+/// [ModelDownloadDialog] and any future caller still compile; every method
+/// short-circuits until flutter_gemma is re-added.
 class FunctionGemmaService {
   static final FunctionGemmaService _instance =
       FunctionGemmaService._internal();
   factory FunctionGemmaService() => _instance;
   FunctionGemmaService._internal();
 
-  bool _isInitialized = false;
-  bool _isModelDownloaded = false;
-  InferenceModel? _model;
-  InferenceChat? _chatSession;
+  bool get isModelReady => false;
 
-  bool get isModelReady =>
-      _isInitialized && _isModelDownloaded && _model != null;
-
-  /// Model download URL for FunctionGemma
   static const String modelUrl =
       'https://huggingface.co/sasha-denisov/function-gemma-270M-it/resolve/main/functiongemma-270M-it.task';
 
-  /// Initialize the flutter_gemma plugin (call once at app start).
   static void initializePlugin() {
-    FlutterGemma.initialize(
-      maxDownloadRetries: 5,
-    );
+    // No-op. See class doc.
   }
 
-  /// Check if the model is already installed.
-  Future<bool> isModelInstalled() async {
-    try {
-      // The method expects a String (model type name), not the enum
-      final result =
-          await FlutterGemma.isModelInstalled(ModelType.functionGemma.name);
-      debugPrint('FlutterGemma.isModelInstalled returned: $result');
-      return result;
-    } catch (e) {
-      debugPrint('Error checking model installation: $e');
-      return false;
-    }
-  }
+  Future<bool> isModelInstalled() async => false;
 
-  /// Initialize the service by trying to load the model.
   Future<void> init() async {
-    debugPrint('FunctionGemmaService.init: Attempting to load model...');
-    await _tryLoadModel();
+    // No-op.
   }
 
-  /// Refresh the model state - call this after model download completes elsewhere.
   Future<void> refreshModelState() async {
-    debugPrint('FunctionGemmaService: Refreshing model state...');
-    await _tryLoadModel();
-    debugPrint('FunctionGemmaService: isModelReady = $isModelReady');
+    // No-op.
   }
 
-  /// Try to load the model directly - if it succeeds, we know it's installed.
-  Future<void> _tryLoadModel() async {
-    if (_model != null) {
-      debugPrint('Model already loaded');
-      return;
-    }
-
-    try {
-      debugPrint('Attempting to get active model...');
-      _model = await FlutterGemma.getActiveModel(
-        maxTokens: 1024,
-        preferredBackend: PreferredBackend.gpu,
-      );
-      _isModelDownloaded = true;
-      _isInitialized = true;
-      debugPrint('FunctionGemma model loaded successfully! Model: $_model');
-    } catch (e) {
-      debugPrint('Could not load model (may not be installed): $e');
-      _isModelDownloaded = false;
-      _isInitialized = false;
-    }
-  }
-
-  /// Download and install the FunctionGemma model.
   Future<void> downloadModel({
     required Function(double progress) onProgress,
   }) async {
-    if (_isModelDownloaded) return;
-
-    try {
-      await FlutterGemma.installModel(
-        modelType: ModelType.functionGemma,
-      )
-          .fromNetwork(
-        modelUrl,
-      )
-          .withProgress((progress) {
-        // progress is an int representing percentage (0-100)
-        onProgress(progress / 100);
-      }).install();
-
-      // Model downloaded, now try to load it
-      await _tryLoadModel();
-    } catch (e) {
-      debugPrint('Model download failed: $e');
-      rethrow;
-    }
+    throw UnsupportedError(
+      'FunctionGemmaService is stubbed for MVP. Re-add flutter_gemma to '
+      'pubspec and restore the real implementation before shipping Game '
+      'Reports.',
+    );
   }
 
-  /// Generate a response from the model using function calling.
-  /// [tools] are the function definitions to provide to the model.
-  Future<String?> generateResponse(String prompt, {List<Tool>? tools}) async {
-    // Auto-refresh state if model isn't ready but might be installed
-    if (!isModelReady) {
-      debugPrint('Model not ready, refreshing state...');
-      await refreshModelState();
-    }
-
-    if (!isModelReady || _model == null) {
-      debugPrint(
-          'Model still not ready after refresh. isModelReady=$isModelReady, model=$_model');
-      return null;
-    }
-
-    try {
-      await _closeChatSession();
-
-      // Create a new chat session for each request
-      _chatSession = await _model!.createChat(
-        tools: tools ?? [],
-        supportsFunctionCalls: true,
-      );
-
-      // Add user query
-      await _chatSession!.addQueryChunk(Message.text(
-        text: prompt,
-        isUser: true,
-      ));
-
-      // Generate response (returns sealed ModelResponse, pattern match to extract)
-      final response = await _chatSession!.generateChatResponse();
-
-      // Handle different response types
-      return switch (response) {
-        TextResponse(token: final text) => text,
-        FunctionCallResponse(name: final name, args: final args) =>
-          'FUNCTION_CALL:$name:${args.toString()}',
-        ThinkingResponse(content: final content) => content,
-      };
-    } catch (e) {
-      debugPrint('Inference error: $e');
-      return null;
-    } finally {
-      await _closeChatSession();
-    }
+  Future<String?> generateResponse(
+    String prompt, {
+    List<Object?>? tools,
+  }) async {
+    debugPrint('FunctionGemmaService.generateResponse called on MVP stub');
+    return null;
   }
 
-  /// Cleanup resources when the service is no longer needed.
   Future<void> dispose() async {
-    await _closeChatSession();
-    await _model?.close();
-    _chatSession = null;
-    _model = null;
-    _isInitialized = false;
+    // No-op.
   }
 
-  /// Safely closes the current chat session to prevent memory/GPU leaks.
-  ///
-  /// This method:
-  /// - Captures the session reference locally before nulling to avoid race conditions
-  /// - Nulls [_chatSession] immediately to prevent concurrent access
-  /// - Silently catches and logs any close errors to avoid disrupting the caller
-  ///
-  /// Called automatically:
-  /// - Before creating a new session in [generateResponse]
-  /// - After completing or failing a response in [generateResponse] (via finally)
-  /// - In [dispose] for final cleanup
   @visibleForTesting
-  Future<void> closeChatSession() => _closeChatSession();
-
-  Future<void> _closeChatSession() async {
-    final session = _chatSession;
-    _chatSession = null;
-    if (session == null) {
-      return;
-    }
-
-    try {
-      await session.session.close();
-    } catch (e) {
-      debugPrint('Failed to close chat session: $e');
-    }
+  Future<void> closeChatSession() async {
+    // Exposed for tests; stub is idempotent.
   }
 }

--- a/flutter_app/lib/micro_apps/game_reports/services/game_report_tools.dart
+++ b/flutter_app/lib/micro_apps/game_reports/services/game_report_tools.dart
@@ -1,41 +1,35 @@
-import 'package:flutter_gemma/flutter_gemma.dart';
+/// MVP stub: flutter_gemma is removed from pubspec for MVP, so the real
+/// [Tool] type is unavailable. This local placeholder keeps the file
+/// compiling inside the repo. Replace with the flutter_gemma Tool type when
+/// Game Reports is re-enabled.
+class GameReportsTool {
+  final String name;
+  final String description;
+  const GameReportsTool({required this.name, required this.description});
+}
 
 /// Defines the tools (functions) available for FunctionGemma to call.
-/// These match what the model was trained to recognize.
+/// Dormant in MVP — see [FunctionGemmaService] stub.
 class GameReportTools {
-  /// All available tools for game analysis.
-  static List<Tool> get all => [
-        getGameRecapTool,
-        getStatsBreakdownTool,
-        getPlayerHighlightsTool,
-        getMvpAnalysisTool,
+  static List<GameReportsTool> get all => const [
+        GameReportsTool(
+          name: 'get_game_recap',
+          description:
+              'Get a casual or detailed recap summary of a completed NFL game.',
+        ),
+        GameReportsTool(
+          name: 'get_stats_breakdown',
+          description: 'Get key statistics and numbers from the game.',
+        ),
+        GameReportsTool(
+          name: 'get_player_highlights',
+          description:
+              'Get information about key player performances in the game.',
+        ),
+        GameReportsTool(
+          name: 'get_mvp_analysis',
+          description:
+              'Determine and explain who was the MVP of the game.',
+        ),
       ];
-
-  /// Tool for getting a game recap.
-  static Tool get getGameRecapTool => const Tool(
-        name: 'get_game_recap',
-        description:
-            'Get a casual or detailed recap summary of a completed NFL game. Use this for requests about recaps, summaries, or game overviews.',
-      );
-
-  /// Tool for getting stats breakdown.
-  static Tool get getStatsBreakdownTool => const Tool(
-        name: 'get_stats_breakdown',
-        description:
-            'Get key statistics and numbers from the game. Use this for requests about stats, numbers, scores, or data.',
-      );
-
-  /// Tool for getting player highlights.
-  static Tool get getPlayerHighlightsTool => const Tool(
-        name: 'get_player_highlights',
-        description:
-            'Get information about key player performances in the game. Use this for questions about specific players or player stats.',
-      );
-
-  /// Tool for MVP analysis.
-  static Tool get getMvpAnalysisTool => const Tool(
-        name: 'get_mvp_analysis',
-        description:
-            'Determine and explain who was the MVP (Most Valuable Player) of the game. Use this for questions about the best player or MVP.',
-      );
 }

--- a/flutter_app/lib/micro_apps/game_reports/services/game_report_tools.dart
+++ b/flutter_app/lib/micro_apps/game_reports/services/game_report_tools.dart
@@ -28,8 +28,7 @@ class GameReportTools {
         ),
         GameReportsTool(
           name: 'get_mvp_analysis',
-          description:
-              'Determine and explain who was the MVP of the game.',
+          description: 'Determine and explain who was the MVP of the game.',
         ),
       ];
 }

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -105,14 +105,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.25"
-  background_downloader:
-    dependency: transitive
-    description:
-      name: background_downloader
-      sha256: "1e8b71f7fe841da0b24f672318e8d0038d3bae0c9939bd05b60e411adf40ab59"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.5.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -326,14 +318,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.1"
-  flutter_gemma:
-    dependency: "direct main"
-    description:
-      name: flutter_gemma
-      sha256: cb16272874da09efe9389fa27206a4a476dff1b542a4362ab5b3b24bad22f2d5
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.11.16"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -538,14 +522,6 @@ packages:
     description:
       name: jwt_decode
       sha256: d2e9f68c052b2225130977429d30f187aa1981d789c76ad104a32243cfdebfbb
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
-  large_file_handler:
-    dependency: transitive
-    description:
-      name: large_file_handler
-      sha256: c2ecaf552e8039119bbe3a094d15aecbafe833899f30b2dcfbb513eddf76b36f
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -94,13 +94,9 @@ flutter:
     - assets/T4L_app_logo.png
     - assets/logos/nfl_logo.png
     - .env
-    - lib/micro_apps/deep_dive/store_assets/
     - lib/micro_apps/app_store/store_assets/
     - lib/micro_apps/breaking_news/store_assets/
-    - lib/micro_apps/radio/store_assets/
     - lib/micro_apps/standings/store_assets/
-    - lib/micro_apps/game_reports/store_assets/
-    - lib/micro_apps/player_wordle/store_assets/
 
     - assets/creative_logos/
     - assets/icons/

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -55,7 +55,9 @@ dependencies:
   path_provider: ^2.1.2
   flutter_svg: ^2.2.3
   flutter_staggered_grid_view: ^0.7.0
-  flutter_gemma: ^0.11.16 # Local Gemma LLM inference for FunctionGemma
+  # flutter_gemma removed for MVP — re-add when Game Reports ships.
+  # Package pulled in TensorFlowLiteSelectTfOps (iOS) / TFLite select ops,
+  # adding ~100MB to the binary with no MVP consumer.
   speech_to_text: ^6.6.0 # Voice input for natural language interaction
   http: ^1.2.0 # HTTP client for Game Analysis Package API
   share_plus: ^10.0.3 # Native share sheet for sharing results

--- a/flutter_app/test/core/onboarding/first_launch_flow_test.dart
+++ b/flutter_app/test/core/onboarding/first_launch_flow_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tackle4loss_mobile/core/onboarding/views/first_launch_flow.dart';
+import 'package:tackle4loss_mobile/core/services/settings_service.dart';
+import 'package:tackle4loss_mobile/core/theme/t4l_theme.dart';
+
+Widget _wrap(Widget child, SettingsService settings) {
+  return ChangeNotifierProvider<SettingsService>.value(
+    value: settings,
+    child: MaterialApp(
+      theme: T4LTheme.light(team: null),
+      home: child,
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('FirstLaunchFlow Continue is disabled until a team is picked',
+      (tester) async {
+    final settings = SettingsService.testing();
+    await mockNetworkImagesFor(() async {
+      await tester.pumpWidget(_wrap(const FirstLaunchFlow(), settings));
+      await tester.pumpAndSettle();
+    });
+
+    final continueBtn = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'CONTINUE'),
+    );
+    expect(continueBtn.onPressed, isNull,
+        reason: 'CONTINUE must be disabled before a team is selected');
+  });
+
+  testWidgets('FirstLaunchFlow advances to language step after team pick',
+      (tester) async {
+    final settings = SettingsService.testing();
+    await mockNetworkImagesFor(() async {
+      await tester.pumpWidget(_wrap(const FirstLaunchFlow(), settings));
+      await tester.pumpAndSettle();
+
+      // Tap the first team tile.
+      await tester.tap(find.byType(GestureDetector).first);
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'CONTINUE'));
+      await tester.pumpAndSettle();
+    });
+
+    expect(find.text('Confirm your language'), findsOneWidget);
+    expect(find.text('English'), findsOneWidget);
+    expect(find.text('Deutsch'), findsOneWidget);
+  });
+
+  testWidgets(
+      'FirstLaunchFlow GET STARTED persists team, language and onboarding flag',
+      (tester) async {
+    final settings = SettingsService.testing();
+    await mockNetworkImagesFor(() async {
+      await tester.pumpWidget(_wrap(const FirstLaunchFlow(), settings));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(GestureDetector).first);
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'CONTINUE'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Deutsch'));
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'GET STARTED'));
+      await tester.pumpAndSettle();
+    });
+
+    expect(settings.onboardingComplete, isTrue);
+    expect(settings.locale.languageCode, 'de');
+    expect(settings.selectedTeam, isNotNull);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('onboarding_complete_v1'), isTrue);
+  });
+
+  testWidgets('FirstLaunchFlow blocks system back via PopScope',
+      (tester) async {
+    final settings = SettingsService.testing();
+    await mockNetworkImagesFor(() async {
+      await tester.pumpWidget(_wrap(const FirstLaunchFlow(), settings));
+      await tester.pumpAndSettle();
+    });
+
+    final popScope = tester.widget<PopScope>(find.byType(PopScope));
+    expect(popScope.canPop, isFalse,
+        reason: 'Onboarding must not be dismissible by system back gesture');
+  });
+}

--- a/flutter_app/test/core/os_shell/controllers/news_feed_controller_test.dart
+++ b/flutter_app/test/core/os_shell/controllers/news_feed_controller_test.dart
@@ -1,208 +1,89 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:tackle4loss_mobile/core/os_shell/controllers/news_feed_controller.dart';
 import 'package:tackle4loss_mobile/core/models/news_feed_item.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:tackle4loss_mobile/core/os_shell/controllers/news_feed_controller.dart';
+import 'package:tackle4loss_mobile/core/services/articles_service.dart';
 
-class MockSupabaseClient extends Mock implements SupabaseClient {}
+class MockArticlesService extends Mock implements ArticlesService {}
 
-class MockFunctionsClient extends Mock implements FunctionsClient {}
-
-class MockRealtimeChannel extends Mock implements RealtimeChannel {}
+NewsFeedItem _item(String id) => NewsFeedItem(
+      id: id,
+      xPost: 'intro $id',
+      headline: 'Headline $id',
+      createdAt: DateTime.parse('2026-04-26T20:15:51.000+00:00'),
+    );
 
 void main() {
+  late MockArticlesService mockArticles;
   late NewsFeedController controller;
-  late MockSupabaseClient mockSupabaseClient;
-  late MockFunctionsClient mockFunctionsClient;
-  late MockRealtimeChannel mockRealtimeChannel;
 
-  setUpAll(() {
-    registerFallbackValue(PostgresChangeEvent.insert);
-  });
-
-  setUp(() async {
-    // Load mock env
-    dotenv.testLoad(fileInput: 'SUPABASE_URL=https://mock.supabase.co');
-
-    mockSupabaseClient = MockSupabaseClient();
-    mockFunctionsClient = MockFunctionsClient();
-    mockRealtimeChannel = MockRealtimeChannel();
-
-    // Setup mocks
-    when(() => mockSupabaseClient.functions).thenReturn(mockFunctionsClient);
-
-    // Mock channel subscription
-    when(() => mockSupabaseClient.channel(any()))
-        .thenReturn(mockRealtimeChannel);
-    when(() => mockRealtimeChannel.onPostgresChanges(
-          event: any(named: 'event'),
-          schema: any(named: 'schema'),
-          table: any(named: 'table'),
-          callback: any(named: 'callback'),
-        )).thenReturn(mockRealtimeChannel);
-    when(() => mockRealtimeChannel.subscribe()).thenReturn(mockRealtimeChannel);
-
-    // Mock functions invoke for loadInitial
-    when(() => mockFunctionsClient.invoke(
-              'get-news-feed',
-              body: any(named: 'body'),
-            ))
-        .thenAnswer((_) async => FunctionResponse(
-            status: 200, data: {'items': [], 'hasMore': false}));
-
+  setUp(() {
+    mockArticles = MockArticlesService();
     controller = NewsFeedController(
       languageCode: 'en',
-      client: mockSupabaseClient,
+      articlesService: mockArticles,
     );
   });
 
   group('NewsFeedController', () {
-    test('loadInitial subscribes to realtime channel and fetches data',
-        () async {
+    test('loadInitial fetches first page from ArticlesService', () async {
+      when(() => mockArticles.fetchArticles(
+            language: 'en',
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+          )).thenAnswer((_) async => ArticlesPage(items: [_item('1')]));
+
       await controller.loadInitial();
 
-      // Verify subscription
-      verify(() => mockSupabaseClient.channel('news-feed-updates')).called(1);
-      verify(() => mockRealtimeChannel.onPostgresChanges(
-            event: PostgresChangeEvent.insert,
-            schema: 'content',
-            table: 'news_updates',
-            callback: any(named: 'callback'),
+      verify(() => mockArticles.fetchArticles(
+            language: 'en',
+            limit: 20,
+            cursor: null,
           )).called(1);
-      verify(() => mockRealtimeChannel.subscribe()).called(1);
-
-      // Verify initial fetch
-      verify(() => mockFunctionsClient.invoke(
-            'get-news-feed',
-            body: {'language_code': 'en', 'limit': 20, 'offset': 0},
-          )).called(1);
-    });
-
-    test('handles realtime insert correctly', () async {
-      // Initialize to trigger the subscription
-      await controller.loadInitial();
-
-      // Capture the callback
-      final capturedCalls = verify(() => mockRealtimeChannel.onPostgresChanges(
-            event: PostgresChangeEvent.insert,
-            schema: 'content',
-            table: 'news_updates',
-            callback: captureAny(named: 'callback'),
-          )).captured;
-
-      final callback =
-          capturedCalls.last as void Function(PostgresChangePayload);
-
-      // Create a dummy payload
-      final payload = PostgresChangePayload(
-        eventType: PostgresChangeEvent.insert,
-        newRecord: {
-          'id': 'new-item-123',
-          'created_at': DateTime.now().toIso8601String(),
-          'headline': 'Realtime Headline',
-          'language_code': 'en',
-          'image_file': 'test.jpg',
-        },
-        oldRecord: {},
-        schema: 'content',
-        table: 'news_updates',
-        commitTimestamp: DateTime.now(),
-        errors: null,
-      );
-
-      // Invoke callback
-      callback(payload);
-
-      // Wait for UI to update (microtask)
-      await Future.delayed(Duration.zero);
-
-      // Verify item was added
       expect(controller.items.length, 1);
-      final item = controller.items.first as NewsFeedItem;
-      expect(item.id, 'new-item-123');
-      expect(item.headline, 'Realtime Headline');
+      expect(controller.hasMore, isFalse);
     });
 
-    test('ignores realtime insert with different language', () async {
-      await controller.loadInitial();
-
-      final capturedCalls = verify(() => mockRealtimeChannel.onPostgresChanges(
-            event: PostgresChangeEvent.insert,
-            schema: 'content',
-            table: 'news_updates',
-            callback: captureAny(named: 'callback'),
-          )).captured;
-
-      final callback =
-          capturedCalls.last as void Function(PostgresChangePayload);
-
-      final payload = PostgresChangePayload(
-        eventType: PostgresChangeEvent.insert,
-        newRecord: {
-          'id': 'de-item-123',
-          'created_at': DateTime.now().toIso8601String(),
-          'headline': 'German Headline',
-          'language_code': 'de', // Different language
-        },
-        oldRecord: {},
-        schema: 'content',
-        table: 'news_updates',
-        commitTimestamp: DateTime.now(),
-        errors: null,
-      );
-
-      callback(payload);
-
-      expect(controller.items, isEmpty);
-    });
-
-    test('loadMore fetches next page and handles duplicates', () async {
-      // Setup initial fetch response
-      when(() => mockFunctionsClient.invoke('get-news-feed',
-          body: any(named: 'body'))).thenAnswer((invocation) async {
-        final body = invocation.namedArguments[#body] as Map;
-        final offset = body['offset'] as int;
-
-        if (offset == 0) {
-          return FunctionResponse(status: 200, data: {
-            'items': [
-              {
-                'id': '1',
-                'headline': 'Item 1',
-                'createdAt': DateTime.now().toIso8601String()
-              }
-            ],
-            'hasMore': true
-          });
-        } else {
-          // Second page returns item 2 AND item 1 (duplicate to test logic)
-          return FunctionResponse(status: 200, data: {
-            'items': [
-              {
-                'id': '2',
-                'headline': 'Item 2',
-                'createdAt': DateTime.now().toIso8601String()
-              },
-              {
-                'id': '1',
-                'headline': 'Item 1',
-                'createdAt': DateTime.now().toIso8601String()
-              } // Duplicate
-            ],
-            'hasMore': false
-          });
-        }
-      });
+    test('loadMore advances by next_cursor and de-duplicates ids', () async {
+      const cursor1 = ArticlesCursor(createdAt: 't1', id: 1);
+      when(() => mockArticles.fetchArticles(
+            language: 'en',
+            limit: 20,
+            cursor: null,
+          )).thenAnswer((_) async => ArticlesPage(
+            items: [_item('1')],
+            nextCursor: cursor1,
+          ));
+      when(() => mockArticles.fetchArticles(
+            language: 'en',
+            limit: 20,
+            cursor: cursor1,
+          )).thenAnswer((_) async => ArticlesPage(
+            items: [_item('2'), _item('1')], // duplicate '1' from page 1
+          ));
 
       await controller.loadInitial();
       expect(controller.items.length, 1);
+      expect(controller.hasMore, isTrue);
 
       await controller.loadMore();
 
-      // Should have 2 items: 1 and 2. The duplicate 1 should be ignored.
-      expect(controller.items.length, 2);
       expect(controller.items.map((e) => e.id), containsAll(['1', '2']));
+      expect(controller.items.length, 2);
+      expect(controller.hasMore, isFalse);
+    });
+
+    test('records error when fetchArticles throws', () async {
+      when(() => mockArticles.fetchArticles(
+            language: any(named: 'language'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+          )).thenThrow(Exception('boom'));
+
+      await controller.loadInitial();
+
+      expect(controller.items, isEmpty);
+      expect(controller.error, contains('boom'));
     });
   });
 }

--- a/flutter_app/test/core/os_shell/controllers/os_shell_controller_test.dart
+++ b/flutter_app/test/core/os_shell/controllers/os_shell_controller_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tackle4loss_mobile/core/os_shell/controllers/os_shell_controller.dart';
+
+void main() {
+  group('OSShellController', () {
+    testWidgets(
+        'initLoadAll resolves isPageReady without invoking get-latest-deepdive',
+        (tester) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      final controller = OSShellController(capturedContext);
+      expect(controller.isPageReady, isFalse,
+          reason: 'controller starts not ready');
+
+      await controller.initLoadAll('en');
+
+      expect(controller.isPageReady, isTrue,
+          reason:
+              'MVP: ready-gate must resolve immediately without Deep Dive fetch');
+      controller.dispose();
+    });
+  });
+}

--- a/flutter_app/test/core/os_shell/widgets/floating_nav_bar_test.dart
+++ b/flutter_app/test/core/os_shell/widgets/floating_nav_bar_test.dart
@@ -4,11 +4,10 @@ import 'package:tackle4loss_mobile/core/os_shell/widgets/t4l_floating_nav_bar.da
 import 'package:tackle4loss_mobile/core/widgets/notification_badge.dart';
 
 void main() {
-  testWidgets('T4LFloatingNavBar renders all buttons',
+  testWidgets('T4LFloatingNavBar renders the 4 MVP buttons',
       (WidgetTester tester) async {
     bool homePressed = false;
     bool gameCenterPressed = false;
-    bool historyPressed = false;
     bool settingsPressed = false;
     bool teamPressed = false;
 
@@ -18,36 +17,30 @@ void main() {
           body: T4LFloatingNavBar(
             onHome: () => homePressed = true,
             onGameCenter: () => gameCenterPressed = true,
-            onHistory: () => historyPressed = true,
             onSettings: () => settingsPressed = true,
             onTeamLogo: () => teamPressed = true,
             homeTooltip: 'Home',
             gameCenterTooltip: 'Game Center',
-            historyTooltip: 'History',
             settingsTooltip: 'Settings',
           ),
         ),
       ),
     );
 
-    // Verify buttons by tooltip
     expect(find.byTooltip('Home'), findsOneWidget);
     expect(find.byTooltip('Game Center'), findsOneWidget);
-    expect(find.byTooltip('History'), findsOneWidget);
     expect(find.byTooltip('Settings'), findsOneWidget);
+    expect(find.byTooltip('History'), findsNothing,
+        reason: 'MVP Dock drops the History button.');
 
     // Center button uses Image, not Icon
     expect(find.byType(Image), findsOneWidget);
 
-    // Test Taps
     await tester.tap(find.byTooltip('Home'));
     expect(homePressed, isTrue);
 
     await tester.tap(find.byTooltip('Game Center'));
     expect(gameCenterPressed, isTrue);
-
-    await tester.tap(find.byTooltip('History'));
-    expect(historyPressed, isTrue);
 
     await tester.tap(find.byTooltip('Settings'));
     expect(settingsPressed, isTrue);
@@ -64,7 +57,6 @@ void main() {
           body: T4LFloatingNavBar(
             onHome: () {},
             onGameCenter: () {},
-            onHistory: () {},
             onSettings: () {},
             onTeamLogo: () {},
             showGameCenterBadge: true,
@@ -73,7 +65,6 @@ void main() {
       ),
     );
 
-    // Verify badge is rendered
     expect(find.byType(NotificationBadge), findsOneWidget);
     expect(find.text('1'), findsOneWidget);
   });
@@ -86,7 +77,6 @@ void main() {
           body: T4LFloatingNavBar(
             onHome: () {},
             onGameCenter: () {},
-            onHistory: () {},
             onSettings: () {},
             onTeamLogo: () {},
             showGameCenterBadge: false,
@@ -95,7 +85,6 @@ void main() {
       ),
     );
 
-    // Badge widget exists but should not render visible content
     expect(find.text('1'), findsNothing);
   });
 }

--- a/flutter_app/test/core/os_shell/widgets/news_feed_widget_test.dart
+++ b/flutter_app/test/core/os_shell/widgets/news_feed_widget_test.dart
@@ -2,66 +2,28 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:tackle4loss_mobile/core/os_shell/widgets/news_feed/news_feed_widget.dart';
+import 'package:tackle4loss_mobile/core/services/articles_service.dart';
 import 'package:tackle4loss_mobile/core/services/settings_service.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class MockSettingsService extends Mock implements SettingsService {}
 
-class MockSupabaseClient extends Mock implements SupabaseClient {}
-
-class MockFunctionsClient extends Mock implements FunctionsClient {}
-
-class MockRealtimeChannel extends Mock implements RealtimeChannel {}
-
-class FakeRealtimeChannel extends Fake implements RealtimeChannel {}
+class MockArticlesService extends Mock implements ArticlesService {}
 
 void main() {
   late MockSettingsService mockSettings;
-  late MockSupabaseClient mockSupabaseClient;
-  late MockFunctionsClient mockFunctionsClient;
-  late MockRealtimeChannel mockRealtimeChannel;
-
-  setUpAll(() {
-    registerFallbackValue(PostgresChangeEvent.insert);
-    registerFallbackValue(FakeRealtimeChannel());
-    // Load mock env
-    dotenv.testLoad(fileInput: 'SUPABASE_URL=https://mock.supabase.co');
-  });
+  late MockArticlesService mockArticles;
 
   setUp(() {
     mockSettings = MockSettingsService();
-    mockSupabaseClient = MockSupabaseClient();
-    mockFunctionsClient = MockFunctionsClient();
-    mockRealtimeChannel = MockRealtimeChannel();
-
-    // Setup default mocks
+    mockArticles = MockArticlesService();
     when(() => mockSettings.locale).thenReturn(const Locale('en'));
     when(() => mockSettings.selectedTeam).thenReturn(null);
-
-    // Setup Supabase mocks
-    when(() => mockSupabaseClient.functions).thenReturn(mockFunctionsClient);
-    when(() => mockSupabaseClient.channel(any()))
-        .thenReturn(mockRealtimeChannel);
-    when(() => mockSupabaseClient.removeChannel(any()))
-        .thenAnswer((_) async => 'ok');
-    when(() => mockRealtimeChannel.onPostgresChanges(
-          event: any(named: 'event'),
-          schema: any(named: 'schema'),
-          table: any(named: 'table'),
-          callback: any(named: 'callback'),
-        )).thenReturn(mockRealtimeChannel);
-    when(() => mockRealtimeChannel.subscribe()).thenReturn(mockRealtimeChannel);
-
-    // Mock empty feed response
-    when(() => mockFunctionsClient.invoke(
-          'get-news-feed',
-          body: any(named: 'body'),
-        )).thenAnswer((_) async => FunctionResponse(
-          status: 200,
-          data: {'items': [], 'hasMore': false},
-        ));
+    when(() => mockArticles.fetchArticles(
+          language: any(named: 'language'),
+          limit: any(named: 'limit'),
+          cursor: any(named: 'cursor'),
+        )).thenAnswer((_) async => const ArticlesPage(items: []));
   });
 
   Widget createTestWidget({
@@ -75,7 +37,7 @@ void main() {
           child: CustomScrollView(
             controller: scrollController,
             slivers: [
-              NewsFeedWidget(supabaseClient: mockSupabaseClient),
+              NewsFeedWidget(articlesService: mockArticles),
             ],
           ),
         ),
@@ -84,143 +46,98 @@ void main() {
   }
 
   group('NewsFeedWidget Initialization', () {
-    testWidgets('renders without crashing', (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget());
-      await tester.pump(); // Allow initial build
-
-      // Widget should be present
-      expect(find.byType(NewsFeedWidget), findsOneWidget);
-    });
-
-    testWidgets('shows loading skeletons initially when loading',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(createTestWidget());
-      await tester.pump(); // Initial build
-
-      // Should show loading state
-      expect(find.byType(CustomScrollView), findsOneWidget);
-    });
-
-    testWidgets('initializes controller on first build',
-        (WidgetTester tester) async {
+    testWidgets('renders without crashing', (tester) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pump();
 
-      // Verify loadInitial was called through the functions client
-      verify(() => mockFunctionsClient.invoke(
-            'get-news-feed',
-            body: {'language_code': 'en', 'limit': 20, 'offset': 0},
+      expect(find.byType(NewsFeedWidget), findsOneWidget);
+    });
+
+    testWidgets('initializes controller on first build', (tester) async {
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+
+      verify(() => mockArticles.fetchArticles(
+            language: 'en',
+            limit: 20,
+            cursor: null,
           )).called(1);
     });
   });
 
   group('NewsFeedWidget Scroll Behavior', () {
-    testWidgets('attaches to primary scroll controller',
-        (WidgetTester tester) async {
+    testWidgets('attaches to primary scroll controller', (tester) async {
       final scrollController = ScrollController();
-
-      await tester.pumpWidget(createTestWidget(
-        scrollController: scrollController,
-      ));
+      await tester
+          .pumpWidget(createTestWidget(scrollController: scrollController));
       await tester.pumpAndSettle();
-
-      // The widget should have attached to the scroll controller
       expect(scrollController.hasClients, isTrue);
     });
 
-    testWidgets('removes scroll listener on dispose',
-        (WidgetTester tester) async {
+    testWidgets('removes scroll listener on dispose', (tester) async {
       final scrollController = ScrollController();
-
-      await tester.pumpWidget(createTestWidget(
-        scrollController: scrollController,
-      ));
+      await tester
+          .pumpWidget(createTestWidget(scrollController: scrollController));
       await tester.pumpAndSettle();
+      final hadClients = scrollController.hasClients;
 
-      final hadListeners = scrollController.hasClients;
-
-      // Dispose the widget
       await tester.pumpWidget(Container());
       await tester.pumpAndSettle();
 
-      // Listeners should have been cleaned up
-      expect(hadListeners, isTrue);
+      expect(hadClients, isTrue);
       expect(scrollController.hasClients, isFalse);
     });
   });
 
   group('NewsFeedWidget Lifecycle', () {
-    testWidgets('reinitializes on language change',
-        (WidgetTester tester) async {
+    testWidgets('reinitializes on language change', (tester) async {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
+      clearInteractions(mockArticles);
 
-      clearInteractions(mockFunctionsClient);
-
-      // Change language using a new SettingsService instance to trigger dependency update
       final newSettings = MockSettingsService();
       when(() => newSettings.locale).thenReturn(const Locale('de'));
       when(() => newSettings.selectedTeam).thenReturn(null);
 
-      // Rebuild
       await tester.pumpWidget(createTestWidget(settingsService: newSettings));
       await tester.pumpAndSettle();
 
-      // Should call loadInitial again with new language
-      verify(() => mockFunctionsClient.invoke(
-            'get-news-feed',
-            body: {'language_code': 'de', 'limit': 20, 'offset': 0},
+      verify(() => mockArticles.fetchArticles(
+            language: 'de',
+            limit: 20,
+            cursor: null,
           )).called(1);
     });
 
-    testWidgets('does not reinitialize if language unchanged',
-        (WidgetTester tester) async {
+    testWidgets('does not reinitialize if language unchanged', (tester) async {
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+      clearInteractions(mockArticles);
+
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      clearInteractions(mockFunctionsClient);
-
-      // Rebuild without changing language
-      await tester.pumpWidget(createTestWidget());
-      await tester.pumpAndSettle();
-
-      // Should not call loadInitial again
-      verifyNever(() => mockFunctionsClient.invoke(
-            'get-news-feed',
-            body: any(named: 'body'),
+      verifyNever(() => mockArticles.fetchArticles(
+            language: any(named: 'language'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
           ));
     });
   });
 
-  group('NewsFeedWidget Pagination Logic', () {
-    test('_loadMoreThreshold is set to 320 pixels', () {
-      // This test verifies the constant is correctly defined
-      // The value is critical to the pagination behavior
-      expect(320.0, equals(320.0)); // Visual documentation of threshold
-    });
-
-    test('_loadMoreThrottle is set to 600ms', () {
-      // This test verifies the throttle duration
-      // Critical for preventing rapid-fire requests
-      expect(const Duration(milliseconds: 600).inMilliseconds, equals(600));
-    });
-  });
-
   group('NewsFeedWidget Error Handling', () {
-    testWidgets('displays error state on load failure',
-        (WidgetTester tester) async {
-      // Mock error response
-      when(() => mockFunctionsClient.invoke(
-            'get-news-feed',
-            body: any(named: 'body'),
-          )).thenThrow(Exception('Network error'));
+    testWidgets('displays error state on load failure', (tester) async {
+      when(() => mockArticles.fetchArticles(
+            language: any(named: 'language'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+          )).thenThrow(Exception('boom'));
 
       await tester.pumpWidget(createTestWidget());
-      await tester.pump();
-      await tester.pump(); // Let controller update
+      await tester.pumpAndSettle();
 
-      // Should eventually show error UI
-      // (exact error UI may depend on controller's error handling)
+      expect(find.text('Failed to load news feed'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
     });
   });
 }

--- a/flutter_app/test/core/services/feature_flag_service_test.dart
+++ b/flutter_app/test/core/services/feature_flag_service_test.dart
@@ -10,16 +10,17 @@ void main() {
     });
 
     group('isEnabled', () {
-      test('returns true for enabled core apps', () {
-        expect(service.isEnabled('app_hub'), isTrue);
+      test('returns true for MVP-enabled apps', () {
         expect(service.isEnabled('breaking_news'), isTrue);
-        expect(service.isEnabled('deep_dive'), isTrue);
-        expect(service.isEnabled('radio'), isTrue);
         expect(service.isEnabled('standings'), isTrue);
       });
 
-      test('returns false for game_reports (in development)', () {
+      test('returns false for apps deferred from MVP', () {
+        expect(service.isEnabled('app_hub'), isFalse);
+        expect(service.isEnabled('deep_dive'), isFalse);
+        expect(service.isEnabled('radio'), isFalse);
         expect(service.isEnabled('game_reports'), isFalse);
+        expect(service.isEnabled('player_wordle'), isFalse);
       });
 
       test('returns false for unknown feature keys', () {

--- a/flutter_app/test/core/services/installed_apps_service_test.dart
+++ b/flutter_app/test/core/services/installed_apps_service_test.dart
@@ -11,7 +11,10 @@ import 'package:tackle4loss_mobile/micro_apps/player_wordle/player_wordle_app.da
 import 'package:tackle4loss_mobile/micro_apps/game_reports/game_reports_app.dart';
 
 void main() {
-  group('InstalledAppsService', skip: 'MVP: install/reorder logic deprecated; will be revisited when AppStrip returns', () {
+  group('InstalledAppsService',
+      skip:
+          'MVP: install/reorder logic deprecated; will be revisited when AppStrip returns',
+      () {
     late InstalledAppsService service;
 
     setUp(() async {

--- a/flutter_app/test/core/services/installed_apps_service_test.dart
+++ b/flutter_app/test/core/services/installed_apps_service_test.dart
@@ -11,7 +11,7 @@ import 'package:tackle4loss_mobile/micro_apps/player_wordle/player_wordle_app.da
 import 'package:tackle4loss_mobile/micro_apps/game_reports/game_reports_app.dart';
 
 void main() {
-  group('InstalledAppsService', () {
+  group('InstalledAppsService', skip: 'MVP: install/reorder logic deprecated; will be revisited when AppStrip returns', () {
     late InstalledAppsService service;
 
     setUp(() async {

--- a/flutter_app/test/core/services/reorder_logic_test.dart
+++ b/flutter_app/test/core/services/reorder_logic_test.dart
@@ -24,7 +24,10 @@ void main() {
     registry.register(AppHubApp());
   });
 
-  test('Service initializes with default apps', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
+  test('Service initializes with default apps',
+      skip:
+          'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns',
+      () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -38,7 +41,10 @@ void main() {
     expect(service.isInstalled('app_hub'), false);
   });
 
-  test('Install app adds to the end of the list', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
+  test('Install app adds to the end of the list',
+      skip:
+          'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns',
+      () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -52,7 +58,10 @@ void main() {
     expect(service.getItemAt(service.rawItems.length - 1), 'app_hub');
   });
 
-  test('Uninstall app removes it from the list', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
+  test('Uninstall app removes it from the list',
+      skip:
+          'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns',
+      () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -63,7 +72,10 @@ void main() {
     expect(service.isInstalled('breaking_news'), false);
   });
 
-  test('Move app reorders the list correctly', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
+  test('Move app reorders the list correctly',
+      skip:
+          'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns',
+      () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -86,7 +98,10 @@ void main() {
     // but effectively we moved item at index 0 to index 1.
   });
 
-  test('Move app to start', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
+  test('Move app to start',
+      skip:
+          'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns',
+      () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 

--- a/flutter_app/test/core/services/reorder_logic_test.dart
+++ b/flutter_app/test/core/services/reorder_logic_test.dart
@@ -24,7 +24,7 @@ void main() {
     registry.register(AppHubApp());
   });
 
-  test('Service initializes with default apps', () async {
+  test('Service initializes with default apps', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -38,7 +38,7 @@ void main() {
     expect(service.isInstalled('app_hub'), false);
   });
 
-  test('Install app adds to the end of the list', () async {
+  test('Install app adds to the end of the list', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -52,7 +52,7 @@ void main() {
     expect(service.getItemAt(service.rawItems.length - 1), 'app_hub');
   });
 
-  test('Uninstall app removes it from the list', () async {
+  test('Uninstall app removes it from the list', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -63,7 +63,7 @@ void main() {
     expect(service.isInstalled('breaking_news'), false);
   });
 
-  test('Move app reorders the list correctly', () async {
+  test('Move app reorders the list correctly', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 
@@ -86,7 +86,7 @@ void main() {
     // but effectively we moved item at index 0 to index 1.
   });
 
-  test('Move app to start', () async {
+  test('Move app to start', skip: 'MVP: reorder/install logic deprecated; will be revisited when AppStrip returns', () async {
     final service = InstalledAppsService();
     service.resetDefaults();
 

--- a/flutter_app/test/core/services/settings_service_test.dart
+++ b/flutter_app/test/core/services/settings_service_test.dart
@@ -133,6 +133,44 @@ void main() {
       });
     });
 
+    group('onboarding', () {
+      test('onboardingComplete defaults to false', () {
+        expect(service.onboardingComplete, isFalse);
+      });
+
+      test('isLoaded defaults to false on testing constructor', () {
+        expect(service.isLoaded, isFalse);
+      });
+
+      test('markOnboardingComplete flips flag and notifies', () async {
+        bool notified = false;
+        service.addListener(() => notified = true);
+
+        await service.markOnboardingComplete();
+
+        expect(service.onboardingComplete, isTrue);
+        expect(notified, isTrue);
+      });
+
+      test('markOnboardingComplete is idempotent', () async {
+        await service.markOnboardingComplete();
+
+        bool notified = false;
+        service.addListener(() => notified = true);
+        await service.markOnboardingComplete();
+
+        expect(notified, isFalse,
+            reason: 'second call should be a no-op');
+      });
+
+      test('markOnboardingComplete persists to SharedPreferences', () async {
+        await service.markOnboardingComplete();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool('onboarding_complete_v1'), isTrue);
+      });
+    });
+
     group('backgroundGradient', () {
       test('returns default gradient when no team selected (light mode)', () {
         final gradient = service.backgroundGradient;

--- a/flutter_app/test/core/services/settings_service_test.dart
+++ b/flutter_app/test/core/services/settings_service_test.dart
@@ -159,8 +159,7 @@ void main() {
         service.addListener(() => notified = true);
         await service.markOnboardingComplete();
 
-        expect(notified, isFalse,
-            reason: 'second call should be a no-op');
+        expect(notified, isFalse, reason: 'second call should be a no-op');
       });
 
       test('markOnboardingComplete persists to SharedPreferences', () async {


### PR DESCRIPTION
## Summary
- V3 designs implemented for the home feed (`BreakingFeaturedCard`, `BreakingListItemCard`), floating dock (`T4LFloatingNavBar` + reusable `AppDock`), and article detail (`BreakingNewsDetailScreen` with parallax hero, reading-progress bar, byline, body, related stories).
- Home feed cards now navigate directly to the detail screen via `feed_navigation.dart`; the dock stays visible on the detail screen via `bottomNavigationBar` + `extendBody`.
- Home feed and detail switched to a dedicated articles Supabase project: new `ArticlesService` with cursor pagination + BCP-47 language mapping (`en` → `en-US`, `de` → `de-DE`); `NewsFeedController` rewritten, realtime subscription dropped; detail screen accepts injectable fetchers (legacy `BreakingNewsService` remains the default for other callers).

## Test plan
- [x] `flutter analyze --fatal-warnings` — clean (only 2 pre-existing radio info lints)
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `flutter test` — 218 passed, 22 skipped, 0 failures
- [x] Manual: home feed loads articles in EN, then switch locale to DE in Settings → DE articles appear
- [x] Manual: tap a feed card → detail screen renders with hero image, byline, body
- [x] Manual: floating dock visible on detail screen, Home/Schedule/Settings + team badge all functional
- [x] Manual: dark-mode pass on home feed (category eyebrow uses bright green) and detail screen (text/divider/sheet adapt)

## Notes
- `flutter_app/.env` (gitignored) needs `ARTICLES_SUPABASE_URL` and `ARTICLES_SUPABASE_ANON_KEY` for local runs and CI placeholders.
- `get-article-detail` currently ignores the `language` param server-side; we forward it for forward-compat. Sibling articles use language-specific ids in the new project.
- `ArticlesService.fetchRelatedStories` is a no-op stub — the new project doesn't expose related stories yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)