### PR TITLE
refactor(flutter): tighten news feed + article detail chrome

### DIFF
--- a/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_featured_card.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_featured_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:tackle4loss_mobile/design_tokens.dart';
 import '../../../models/news_feed_item.dart';
 import '../../../services/team_logo_service.dart';
 import 'feed_navigation.dart';
@@ -15,19 +14,8 @@ class BreakingFeaturedCard extends StatefulWidget {
   State<BreakingFeaturedCard> createState() => _BreakingFeaturedCardState();
 }
 
-class _BreakingFeaturedCardState extends State<BreakingFeaturedCard>
-    with SingleTickerProviderStateMixin {
+class _BreakingFeaturedCardState extends State<BreakingFeaturedCard> {
   bool _pressed = false;
-  late final AnimationController _pulse = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 1200),
-  )..repeat(reverse: true);
-
-  @override
-  void dispose() {
-    _pulse.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +24,6 @@ class _BreakingFeaturedCardState extends State<BreakingFeaturedCard>
         ? item.teams!.first['team_id']?.toString().toLowerCase() ?? ''
         : '';
     final headline = (item.headline ?? item.xPost).toUpperCase();
-    final category = (item.headline ?? 'BREAKING').toUpperCase();
     final timeLabel = _timeAgo(item.createdAt);
 
     return Padding(
@@ -111,22 +98,25 @@ class _BreakingFeaturedCardState extends State<BreakingFeaturedCard>
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
                           children: [
-                            _breakingPill(),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                category,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  fontSize: 9,
-                                  fontWeight: FontWeight.w700,
-                                  letterSpacing: 1.2,
-                                  color: Color(0x73FFFFFF),
+                            if (firstTeamId.isNotEmpty)
+                              Container(
+                                width: 28,
+                                height: 28,
+                                decoration: BoxDecoration(
+                                  color: Colors.white,
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                padding: const EdgeInsets.all(3),
+                                child: Image.asset(
+                                  TeamLogoService.getLogoPath(firstTeamId),
+                                  fit: BoxFit.contain,
+                                  errorBuilder: (_, __, ___) =>
+                                      const SizedBox(),
                                 ),
                               ),
-                            ),
+                            const Spacer(),
                             Text(
                               timeLabel,
                               style: const TextStyle(
@@ -137,23 +127,6 @@ class _BreakingFeaturedCardState extends State<BreakingFeaturedCard>
                             ),
                           ],
                         ),
-                        const SizedBox(height: 12),
-                        if (firstTeamId.isNotEmpty)
-                          Container(
-                            width: 36,
-                            height: 36,
-                            margin: const EdgeInsets.only(bottom: 10),
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            padding: const EdgeInsets.all(4),
-                            child: Image.asset(
-                              TeamLogoService.getLogoPath(firstTeamId),
-                              fit: BoxFit.contain,
-                              errorBuilder: (_, __, ___) => const SizedBox(),
-                            ),
-                          ),
                         if (item.imageUrl != null) const SizedBox(height: 80),
                         Text(
                           headline,
@@ -208,44 +181,6 @@ class _BreakingFeaturedCardState extends State<BreakingFeaturedCard>
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _breakingPill() {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
-      decoration: BoxDecoration(
-        color: AppColors.breakingNewsRedBright.withValues(alpha: 0.20),
-        border: Border.all(
-            color: AppColors.breakingNewsRedBright.withValues(alpha: 0.40)),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          FadeTransition(
-            opacity: Tween<double>(begin: 1.0, end: 0.45).animate(_pulse),
-            child: Container(
-              width: 6,
-              height: 6,
-              decoration: const BoxDecoration(
-                color: AppColors.breakingNewsRedBright,
-                shape: BoxShape.circle,
-              ),
-            ),
-          ),
-          const SizedBox(width: 5),
-          const Text(
-            'BREAKING',
-            style: TextStyle(
-              fontSize: 9,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 1.4,
-              color: AppColors.breakingNewsRedBright,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
@@ -43,7 +43,8 @@ class _BreakingListItemCardState extends State<BreakingListItemCard> {
     final firstTeamId = (item.teams != null && item.teams!.isNotEmpty)
         ? item.teams!.first['team_id']?.toString().toLowerCase() ?? ''
         : '';
-    final cat = (item.headline ?? 'NEWS').toUpperCase();
+    final cat = item.xPost.trim();
+    final body = (item.headline ?? item.xPost).trim();
     final timeLabel = _timeAgo(item.createdAt);
 
     return GestureDetector(
@@ -96,15 +97,13 @@ class _BreakingListItemCardState extends State<BreakingListItemCard> {
                 children: [
                   Row(
                     children: [
-                      Flexible(
-                        child: Text(
-                          cat,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                      Expanded(
+                        child: _MarqueeText(
+                          text: cat,
                           style: TextStyle(
-                            fontSize: 9,
-                            fontWeight: FontWeight.w800,
-                            letterSpacing: 1.2,
+                            fontSize: 10,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 0.2,
                             color: categoryColor,
                           ),
                         ),
@@ -122,7 +121,7 @@ class _BreakingListItemCardState extends State<BreakingListItemCard> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    item.xPost,
+                    body,
                     maxLines: 3,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
@@ -156,5 +155,94 @@ class _BreakingListItemCardState extends State<BreakingListItemCard> {
     if (d.inHours < 24) return '${d.inHours}h';
     if (d.inDays < 7) return '${d.inDays}d';
     return '${dt.month}/${dt.day}';
+  }
+}
+
+class _MarqueeText extends StatefulWidget {
+  final String text;
+  final TextStyle style;
+
+  const _MarqueeText({
+    required this.text,
+    required this.style,
+  });
+
+  static const double _pixelsPerSecond = 14;
+  static const double _gap = 48;
+
+  @override
+  State<_MarqueeText> createState() => _MarqueeTextState();
+}
+
+class _MarqueeTextState extends State<_MarqueeText>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  double _loopWidth = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this, duration: const Duration(days: 1))
+      ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tp = TextPainter(
+      text: TextSpan(text: widget.text, style: widget.style),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    )..layout();
+    final textW = tp.width;
+    final textH = tp.height;
+    _loopWidth = textW + _MarqueeText._gap;
+    final period = _loopWidth / _MarqueeText._pixelsPerSecond;
+
+    return ClipRect(
+      child: SizedBox(
+        height: textH,
+        width: double.infinity,
+        child: AnimatedBuilder(
+          animation: _ctrl,
+          builder: (_, __) {
+            final t = (_ctrl.lastElapsedDuration?.inMicroseconds ?? 0) /
+                1e6 %
+                period;
+            final dx = -_MarqueeText._pixelsPerSecond * t;
+            return Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Positioned(
+                  left: dx,
+                  top: 0,
+                  child: Text(
+                    widget.text,
+                    maxLines: 1,
+                    softWrap: false,
+                    style: widget.style,
+                  ),
+                ),
+                Positioned(
+                  left: dx + _loopWidth,
+                  top: 0,
+                  child: Text(
+                    widget.text,
+                    maxLines: 1,
+                    softWrap: false,
+                    style: widget.style,
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
   }
 }

--- a/flutter_app/lib/core/services/articles_service.dart
+++ b/flutter_app/lib/core/services/articles_service.dart
@@ -174,6 +174,7 @@ class ArticlesService {
       players: mentioned.isEmpty ? null : mentioned,
       sourceUrl: firstSource?['url'] as String?,
       sourceName: firstSource?['name'] as String?,
+      author: json['author'] as String?,
     );
   }
 }

--- a/flutter_app/lib/micro_apps/breaking_news/models/breaking_news_article.dart
+++ b/flutter_app/lib/micro_apps/breaking_news/models/breaking_news_article.dart
@@ -109,6 +109,7 @@ class BreakingNewsArticle {
   final String? audioFile;
   final String? sourceUrl;
   final String? imageSource;
+  final String? author;
 
   BreakingNewsArticle({
     required this.id,
@@ -125,6 +126,7 @@ class BreakingNewsArticle {
     this.audioFile,
     this.sourceUrl,
     this.imageSource,
+    this.author,
     String? sourceName,
   }) : _sourceName = sourceName;
 
@@ -175,6 +177,7 @@ class BreakingNewsArticle {
       audioFile: json['audioFile'] as String?,
       sourceUrl: (json['source_url'] ?? json['sourceUrl']) as String?,
       imageSource: (json['image_source'] ?? json['imageSource']) as String?,
+      author: json['author'] as String?,
       // Pass source_name through constructor to private field
       sourceName: (json['source_name'] ?? json['sourceName']) as String?,
     );

--- a/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
+++ b/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
@@ -430,7 +430,7 @@ class _Body extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _BylineBar(
-            article: article,
+            article: fullForRead,
             readMins: readMins,
             colors: colors,
             isDark: isDark,

--- a/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
+++ b/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
@@ -205,11 +205,6 @@ class _BreakingNewsDetailScreenState extends State<BreakingNewsDetailScreen> {
                           ],
                         ),
                       ),
-                      _GlassIconButton(
-                        onTap: () => _share(article),
-                        icon: Icons.ios_share_outlined,
-                        iconColor: colors.brand,
-                      ),
                     ],
                   ),
                 ),
@@ -221,15 +216,6 @@ class _BreakingNewsDetailScreenState extends State<BreakingNewsDetailScreen> {
     );
   }
 
-  Future<void> _share(BreakingNewsArticle article) async {
-    final url = article.sourceUrl;
-    if (url == null) return;
-    final uri = Uri.tryParse(url);
-    if (uri == null) return;
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
-  }
 }
 
 // ─── Hero ────────────────────────────────────────────────────────────
@@ -247,7 +233,6 @@ class _Hero extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
     final parallax = (scrollY * 0.35).clamp(0.0, 60.0);
     final overlayOpacity = (0.55 + scrollY * 0.001).clamp(0.55, 0.88);
 
@@ -309,20 +294,6 @@ class _Hero extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  // Update vs. Breaking eyebrow pill
-                  if (article.isUpdate)
-                    _EyebrowPill(
-                      text: l10n.breakingNewsUpdateTag,
-                      bg: AppColors.breakingNewsRed,
-                      fg: Colors.white,
-                    )
-                  else
-                    _EyebrowPill(
-                      text: l10n.breakingNewsTag,
-                      bg: const Color(0xFFC9A256),
-                      fg: AppColors.brandBase,
-                    ),
-                  const SizedBox(height: 12),
                   Text(
                     article.headline.toUpperCase(),
                     style: GoogleFonts.anton(
@@ -363,33 +334,6 @@ class _Hero extends StatelessWidget {
   }
 }
 
-class _EyebrowPill extends StatelessWidget {
-  final String text;
-  final Color bg;
-  final Color fg;
-  const _EyebrowPill({required this.text, required this.bg, required this.fg});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-          fontSize: 9,
-          fontWeight: FontWeight.w800,
-          letterSpacing: 1.4,
-          color: fg,
-        ),
-      ),
-    );
-  }
-}
-
 // ─── Glass header buttons ────────────────────────────────────────────
 
 class _GlassPillButton extends StatelessWidget {
@@ -404,29 +348,6 @@ class _GlassPillButton extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.fromLTRB(10, 7, 13, 7),
         child: child,
-      ),
-    );
-  }
-}
-
-class _GlassIconButton extends StatelessWidget {
-  final VoidCallback onTap;
-  final IconData icon;
-  final Color iconColor;
-  const _GlassIconButton({
-    required this.onTap,
-    required this.icon,
-    required this.iconColor,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return _GlassSurface(
-      onTap: onTap,
-      child: SizedBox(
-        width: 36,
-        height: 36,
-        child: Icon(icon, size: 16, color: iconColor),
       ),
     );
   }
@@ -649,6 +570,7 @@ class _Body extends StatelessWidget {
                   ),
                 ),
               ),
+            _SourceFooter(article: fullArticle!, colors: colors),
             const SizedBox(height: 32),
             FutureBuilder<List<RelatedStory>>(
               future: relatedFuture,
@@ -697,11 +619,8 @@ class _BylineBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sourceUri =
-        article.sourceUrl != null ? Uri.tryParse(article.sourceUrl!) : null;
-    final hasValidSourceUrl = sourceUri != null &&
-        (sourceUri.isScheme('http') || sourceUri.isScheme('https'));
-    final hasSource = article.sourceName != 'Source';
+    final author = (article.author ?? '').trim();
+    final hasAuthor = author.isNotEmpty;
     final dividerColor =
         (isDark ? Colors.white : AppColors.brandBase).withValues(alpha: 0.10);
 
@@ -710,49 +629,40 @@ class _BylineBar extends StatelessWidget {
       child: Column(
         children: [
           Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              if (hasSource)
-                Flexible(
-                  child: GestureDetector(
-                    onTap: hasValidSourceUrl
-                        ? () async {
-                            if (await canLaunchUrl(sourceUri)) {
-                              await launchUrl(sourceUri,
-                                  mode: LaunchMode.externalApplication);
-                            }
-                          }
-                        : null,
-                    child: Text(
-                      article.sourceName.toUpperCase(),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+              Expanded(
+                child: Wrap(
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: 8,
+                  runSpacing: 4,
+                  children: [
+                    if (hasAuthor)
+                      Text(
+                        author.toUpperCase(),
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 1.0,
+                          color: colors.brand,
+                        ),
+                      ),
+                    if (hasAuthor)
+                      Text('·',
+                          style: TextStyle(
+                              color: colors.textMuted.withValues(alpha: 0.6))),
+                    Text(
+                      DateFormat('MMM d, y · h:mm a').format(article.createdAt),
                       style: TextStyle(
                         fontSize: 11,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 1.0,
-                        color: colors.brand,
-                        decoration:
-                            hasValidSourceUrl ? TextDecoration.underline : null,
-                        decorationColor: colors.brand,
+                        color: colors.textSecondary,
+                        fontWeight: FontWeight.w500,
                       ),
                     ),
-                  ),
-                ),
-              if (hasSource) const SizedBox(width: 8),
-              if (hasSource)
-                Text('·',
-                    style: TextStyle(
-                        color: colors.textMuted.withValues(alpha: 0.6))),
-              if (hasSource) const SizedBox(width: 8),
-              Text(
-                DateFormat('MMM d, y · h:mm a').format(article.createdAt),
-                style: TextStyle(
-                  fontSize: 11,
-                  color: colors.textSecondary,
-                  fontWeight: FontWeight.w500,
+                  ],
                 ),
               ),
-              const Spacer(),
+              const SizedBox(width: 8),
               Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
@@ -839,6 +749,63 @@ class _TeamChip extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _SourceFooter extends StatelessWidget {
+  final BreakingNewsArticle article;
+  final T4LThemeColors colors;
+  const _SourceFooter({required this.article, required this.colors});
+
+  @override
+  Widget build(BuildContext context) {
+    final url = article.sourceUrl;
+    if (url == null || url.isEmpty) return const SizedBox.shrink();
+    final uri = Uri.tryParse(url);
+    if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
+      return const SizedBox.shrink();
+    }
+    final label = article.sourceName == 'Source'
+        ? uri.host.replaceFirst('www.', '')
+        : article.sourceName;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 24, 20, 0),
+      child: GestureDetector(
+        onTap: () async {
+          if (await canLaunchUrl(uri)) {
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
+          }
+        },
+        child: Row(
+          children: [
+            Text(
+              'Read more at ',
+              style: TextStyle(
+                fontSize: 13,
+                color: colors.textSecondary,
+              ),
+            ),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: colors.brand,
+                  decoration: TextDecoration.underline,
+                  decorationColor: colors.brand,
+                ),
+              ),
+            ),
+            const SizedBox(width: 4),
+            Icon(Icons.open_in_new, size: 13, color: colors.brand),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary

Cleanup pass on the V3 home feed and article detail screens.

**Home feed**
- List item card: swap headline / subhead so the headline reads as the bold title and the `xPost` becomes a single-line, slow-scrolling news-ticker eyebrow above.
- Featured hero card: drop the BREAKING pill and the small uppercase headline category from the top row; move the team logo inline with the `· 13m ago` time label.

**Article detail**
- Drop the BREAKING / UPDATE eyebrow pill above the hero headline.
- Remove the share button from the top-right.
- Replace the source-link byline with the article author; allow it to wrap to a second line instead of truncating with an ellipsis.
- Surface the source as a `Read more at <source>` link at the end of the body content.
- Add `author` to `BreakingNewsArticle` and pass it through from `ArticlesService`.

## Test plan
- [x] Home feed renders the featured hero with logo + time inline, no BREAKING pill.
- [x] List items show the article headline as the bold title; xPost scrolls horizontally as a single-line ticker.
- [x] Article detail hero shows headline only (no eyebrow pill, no share button).
- [x] Byline displays the author full-name (no ellipsis); falls back gracefully when author is null.
- [x] `Read more at <source>` link at the bottom of the body opens the source URL externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)