### PR TITLE
feat(flutter): redesign team center overlay

### DIFF
--- a/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
@@ -211,9 +211,8 @@ class _MarqueeTextState extends State<_MarqueeText>
         child: AnimatedBuilder(
           animation: _ctrl,
           builder: (_, __) {
-            final t = (_ctrl.lastElapsedDuration?.inMicroseconds ?? 0) /
-                1e6 %
-                period;
+            final t =
+                (_ctrl.lastElapsedDuration?.inMicroseconds ?? 0) / 1e6 % period;
             final dx = -_MarqueeText._pixelsPerSecond * t;
             return Stack(
               clipBehavior: Clip.none,

--- a/flutter_app/lib/core/team_center/views/team_center_overlay.dart
+++ b/flutter_app/lib/core/team_center/views/team_center_overlay.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../models/team_model.dart';
 import '../controllers/team_center_controller.dart';
 import 'widgets/daily_update_card.dart';
+import 'widgets/game_carousel.dart';
 import 'widgets/team_menu_button.dart';
 import '../../os_shell/widgets/mini_player.dart';
 import 'team_roster_screen.dart';
@@ -57,7 +58,8 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
     super.initState();
     _controller = TeamCenterController()
       ..loadTeamData(widget.team, languageCode: widget.languageCode)
-      ..loadTeamRoster(widget.team.id);
+      ..loadTeamRoster(widget.team.id)
+      ..loadInjuries(widget.team.id);
 
     // Preload Defense images when roster arrives
     _controller.addListener(_preloadDefenseImages);
@@ -120,9 +122,6 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
                             children: [
                               const SizedBox(height: 10),
 
-                              // MVP: Games Timeline removed from Team Center.
-                              // Roster, Depth Chart, and Injuries remain.
-
                               // Daily Update
                               DailyUpdateCard(
                                 article: controller.todaysArticle,
@@ -156,7 +155,35 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
                                 },
                               ),
 
-                              const SizedBox(height: 30),
+                              const SizedBox(height: 24),
+
+                              // Game carousel (last result + neighbors)
+                              if (controller.allTeamGames.isNotEmpty) ...[
+                                GameCarousel(
+                                  team: widget.team,
+                                  games: controller.allTeamGames,
+                                  initialIndex: controller.startIndex,
+                                ),
+                                const SizedBox(height: 24),
+                              ],
+
+                              // Section label
+                              Padding(
+                                padding: const EdgeInsets.fromLTRB(4, 0, 0, 10),
+                                child: Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: Text(
+                                    'TEAM INFO',
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w700,
+                                      letterSpacing: 1.1,
+                                      color:
+                                          Colors.white.withValues(alpha: 0.4),
+                                    ),
+                                  ),
+                                ),
+                              ),
 
                               // Menu Buttons
                               TeamMenuButton(
@@ -164,6 +191,9 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
                                 icon: Icons.people_outline,
                                 iconAssetPath: 'assets/icons/roster.svg',
                                 color: widget.team.primaryColor,
+                                accentColor: const Color(0xFF0F3D2E),
+                                subtitle: _rosterSubtitle(controller),
+                                statText: _rosterStat(controller),
                                 onTap: () {
                                   final controller = context.read<
                                       TeamCenterController>(); // Get existing controller
@@ -202,6 +232,9 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
                                 icon: Icons.list_alt,
                                 iconAssetPath: 'assets/icons/depth.svg',
                                 color: widget.team.primaryColor,
+                                accentColor: const Color(0xFF1A2F4A),
+                                subtitle: 'Offense · Defense · Special Teams',
+                                statText: '3',
                                 onTap: () {
                                   final controller =
                                       context.read<TeamCenterController>();
@@ -239,6 +272,10 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
                                 icon: Icons.local_hospital_outlined,
                                 iconAssetPath: 'assets/icons/injuries.svg',
                                 color: widget.team.primaryColor,
+                                accentColor: const Color(0xFF3A1010),
+                                subtitle: _injurySubtitle(controller),
+                                statText: _injuryStat(controller),
+                                statColor: const Color(0xE6E06060),
                                 onTap: () {
                                   final controller =
                                       context.read<TeamCenterController>();
@@ -366,5 +403,39 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
         ],
       ),
     );
+  }
+
+  String _rosterSubtitle(TeamCenterController c) {
+    final total = c.offenseRoster.length +
+        c.defenseRoster.length +
+        c.specialTeamsRoster.length;
+    if (total == 0) return 'Active roster';
+    return '$total players · 3 units';
+  }
+
+  String _rosterStat(TeamCenterController c) {
+    final total = c.offenseRoster.length +
+        c.defenseRoster.length +
+        c.specialTeamsRoster.length;
+    return total > 0 ? '$total' : '—';
+  }
+
+  String _injurySubtitle(TeamCenterController c) {
+    final out = c.outInjuries.length;
+    final q = c.questionableInjuries.length;
+    final d = c.doubtfulInjuries.length;
+    if (out + q + d == 0) return 'No reported injuries';
+    final parts = <String>[];
+    if (out > 0) parts.add('$out Out');
+    if (d > 0) parts.add('$d Doubtful');
+    if (q > 0) parts.add('$q Quest.');
+    return parts.join(' · ');
+  }
+
+  String _injuryStat(TeamCenterController c) {
+    final total = c.outInjuries.length +
+        c.questionableInjuries.length +
+        c.doubtfulInjuries.length;
+    return total > 0 ? '$total' : '—';
   }
 }

--- a/flutter_app/lib/core/team_center/views/widgets/daily_update_card.dart
+++ b/flutter_app/lib/core/team_center/views/widgets/daily_update_card.dart
@@ -1,9 +1,14 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
+import '../../../../design_tokens.dart';
 import '../../models/team_article.dart';
 
-class DailyUpdateCard extends StatelessWidget {
-  final TeamArticle? article; // Can be null for loading/empty state
+const Color _kGold = Color(0xFFC9A256);
+const Color _kFieldDark1 = Color(0xFF071810);
+const Color _kFieldDark2 = AppColors.brandBase; // 0xFF0F3D2E
+const Color _kFieldDark3 = Color(0xFF08221A);
+
+class DailyUpdateCard extends StatefulWidget {
+  final TeamArticle? article;
   final VoidCallback onTap;
   final VoidCallback? onImageTap;
   final Color? teamColor;
@@ -17,162 +22,136 @@ class DailyUpdateCard extends StatelessWidget {
   });
 
   @override
+  State<DailyUpdateCard> createState() => _DailyUpdateCardState();
+}
+
+class _DailyUpdateCardState extends State<DailyUpdateCard>
+    with TickerProviderStateMixin {
+  late final AnimationController _chipPulse;
+  late final AnimationController _wave;
+  late final AnimationController _playPulse;
+
+  @override
+  void initState() {
+    super.initState();
+    _chipPulse = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2400),
+    )..repeat();
+    _wave = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    )..repeat();
+    _playPulse = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _chipPulse.dispose();
+    _wave.dispose();
+    _playPulse.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (article == null) {
-      return _buildSkeleton(context);
-    }
+    if (widget.article == null) return _buildSkeleton();
 
-    final displayTitle =
-        article!.title.isNotEmpty ? article!.title : 'Latest Team Update';
+    final title = widget.article!.title.isNotEmpty
+        ? widget.article!.title
+        : 'Latest Team Update';
 
-    return Container(
-      height: 220,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(24),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.3),
-            blurRadius: 15,
-            offset: const Offset(0, 8),
-          ),
-        ],
-      ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(24),
-        child: GestureDetector(
-          onTap: onImageTap,
+    return GestureDetector(
+      onTap: widget.onImageTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: const Color(0xFF0A1F14),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.07)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.4),
+              blurRadius: 32,
+              offset: const Offset(0, 8),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(18),
           child: Stack(
-            fit: StackFit.expand,
             children: [
-              // Hero Image
-              Image.network(
-                article!.imageUrl.isNotEmpty
-                    ? article!.imageUrl
-                    : 'https://images.unsplash.com/photo-1566577739112-5180d4bf9390?q=80&w=3426&auto=format&fit=crop',
-                fit: BoxFit.cover,
-                errorBuilder: (context, error, stackTrace) => Container(
-                  color: const Color(0xFF1F2937),
-                  child: const Center(
-                    child: Icon(Icons.image_not_supported,
-                        color: Colors.white24, size: 40),
+              // Field gradient base
+              const Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [_kFieldDark1, _kFieldDark2, _kFieldDark3],
+                      stops: [0.0, 0.55, 1.0],
+                    ),
                   ),
                 ),
               ),
-
-              // Gradient Overlay
-              Container(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      Colors.black.withValues(alpha: 0.0),
-                      Colors.black.withValues(alpha: 0.6),
-                      Colors.black.withValues(alpha: 0.9),
-                    ],
-                    stops: const [0.3, 0.7, 1.0],
+              // Field-line watermark
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: Opacity(
+                    opacity: 0.045,
+                    child: CustomPaint(painter: _FieldLinesPainter()),
+                  ),
+                ),
+              ),
+              // Bottom fade
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.bottomCenter,
+                      end: Alignment.topCenter,
+                      colors: [
+                        Colors.black.withValues(alpha: 0.6),
+                        Colors.transparent,
+                      ],
+                      stops: const [0.0, 0.6],
+                    ),
                   ),
                 ),
               ),
 
               // Content
               Padding(
-                padding: const EdgeInsets.all(20),
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 14),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Badge
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: (teamColor ?? const Color(0xFF0F5132))
-                            .withValues(alpha: 0.2),
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                          color: (teamColor ?? const Color(0xFF4ADE80))
-                              .withValues(alpha: 0.5),
-                          width: 1,
-                        ),
-                      ),
-                      child: Text(
-                        'DAILY UPDATE',
-                        style: TextStyle(
-                          color: teamColor ?? const Color(0xFF4ADE80),
-                          fontSize: 10,
-                          fontWeight: FontWeight.w900,
-                          letterSpacing: 0.5,
-                        ),
+                    _buildGoldChip(),
+                    const SizedBox(height: 12),
+                    Text(
+                      title.toUpperCase(),
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontFamily: 'Russo One',
+                        fontSize: 17,
+                        height: 1.2,
+                        letterSpacing: 0.17,
+                        color: Colors.white,
+                        shadows: [
+                          Shadow(
+                            color: Color(0x66000000),
+                            offset: Offset(0, 2),
+                            blurRadius: 8,
+                          ),
+                        ],
                       ),
                     ),
-
-                    const Spacer(),
-
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        // Text Info
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                displayTitle, // "Coach Saleh on Strategy..."
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 20,
-                                  fontWeight: FontWeight.bold,
-                                  height: 1.2,
-                                ),
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                              const SizedBox(height: 8),
-                              Text(
-                                // Placeholder format: "October 14 • 2 min watch"
-                                // In real app, format article!.publishedAt
-                                'Today • Listen now',
-                                style: TextStyle(
-                                  color: Colors.white.withValues(alpha: 0.7),
-                                  fontSize: 13,
-                                  fontWeight: FontWeight.w500,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-
-                        const SizedBox(width: 16),
-
-                        // Glassmorphic Play Button
-                        GestureDetector(
-                          onTap: onTap,
-                          child: ClipOval(
-                            child: BackdropFilter(
-                              filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                              child: Container(
-                                width: 56,
-                                height: 56,
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: Colors.white.withValues(alpha: 0.2),
-                                  border: Border.all(
-                                    color: Colors.white.withValues(alpha: 0.3),
-                                    width: 1.5,
-                                  ),
-                                ),
-                                child: const Icon(
-                                  Icons.play_arrow_rounded,
-                                  color: Colors.white,
-                                  size: 32,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                    const SizedBox(height: 14),
+                    _buildBottomRow(),
                   ],
                 ),
               ),
@@ -183,18 +162,237 @@ class DailyUpdateCard extends StatelessWidget {
     );
   }
 
-  Widget _buildSkeleton(BuildContext context) {
-    return Container(
-      height: 220,
-      decoration: BoxDecoration(
-        color: const Color(0xFF1F2937),
-        borderRadius: BorderRadius.circular(24),
-      ),
-      child: const Center(
-        child: CircularProgressIndicator(
-          color: Colors.white24,
+  Widget _buildGoldChip() {
+    return AnimatedBuilder(
+      animation: _chipPulse,
+      builder: (_, __) {
+        final t = _chipPulse.value; // 0..1
+        // scale 1 -> 1.03 -> 1
+        final scale = 1.0 + 0.03 * (t < 0.5 ? t * 2 : (1 - t) * 2);
+        // ring 0..7px, opacity 0.55 -> 0
+        final ringSize = 7.0 * t;
+        final ringAlpha = (0.55 * (1 - t)).clamp(0.0, 1.0);
+        return Transform.scale(
+          scale: scale,
+          alignment: Alignment.centerLeft,
+          child: Container(
+            decoration: BoxDecoration(
+              color: _kGold,
+              borderRadius: BorderRadius.circular(999),
+              boxShadow: [
+                BoxShadow(
+                  color: _kGold.withValues(alpha: ringAlpha),
+                  blurRadius: 0,
+                  spreadRadius: ringSize,
+                ),
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.3),
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 4),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.headphones, size: 11, color: AppColors.brandBase),
+                SizedBox(width: 5),
+                Text(
+                  'DAILY UPDATE',
+                  style: TextStyle(
+                    fontSize: 9,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0.9,
+                    color: AppColors.brandBase,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildBottomRow() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        _buildWaveform(),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'TODAY · LISTEN',
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.6,
+                  color: Colors.white.withValues(alpha: 0.5),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Container(
+                height: 2,
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+                child: FractionallySizedBox(
+                  alignment: Alignment.centerLeft,
+                  widthFactor: 0.38,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: _kGold,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '3:04 / 8:22',
+                style: TextStyle(
+                  fontSize: 9,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.white.withValues(alpha: 0.28),
+                ),
+              ),
+            ],
+          ),
         ),
+        const SizedBox(width: 10),
+        _buildPlayButton(),
+      ],
+    );
+  }
+
+  Widget _buildWaveform() {
+    const barCount = 12;
+    return SizedBox(
+      height: 22,
+      width: barCount * 4.5,
+      child: AnimatedBuilder(
+        animation: _wave,
+        builder: (_, __) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: List.generate(barCount, (i) {
+              final phase = (_wave.value + i * 0.08) % 1.0;
+              // sin-like 4..20 height
+              final tri = phase < 0.5 ? phase * 2 : (1 - phase) * 2;
+              final h = 4.0 + 16.0 * tri;
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 1),
+                child: Container(
+                  width: 2.5,
+                  height: h,
+                  decoration: BoxDecoration(
+                    color: _kGold.withValues(alpha: 0.7),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              );
+            }),
+          );
+        },
       ),
     );
   }
+
+  Widget _buildPlayButton() {
+    return GestureDetector(
+      onTap: widget.onTap,
+      child: AnimatedBuilder(
+        animation: _playPulse,
+        builder: (_, __) {
+          final t = _playPulse.value;
+          final ring = 8.0 * t;
+          final alpha = (0.3 * (1 - t)).clamp(0.0, 1.0);
+          return Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.white.withValues(alpha: alpha),
+                  blurRadius: 0,
+                  spreadRadius: ring,
+                ),
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.3),
+                  blurRadius: 16,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: const Icon(
+              Icons.play_arrow_rounded,
+              color: AppColors.brandBase,
+              size: 24,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSkeleton() {
+    return Container(
+      height: 168,
+      decoration: BoxDecoration(
+        color: const Color(0xFF0A1F14),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: const Center(
+        child: CircularProgressIndicator(color: Colors.white24),
+      ),
+    );
+  }
+}
+
+class _FieldLinesPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 1
+      ..style = PaintingStyle.stroke;
+    // Vertical yard lines
+    const cols = 9;
+    final step = size.width / (cols - 1);
+    for (int i = 0; i < cols; i++) {
+      final x = i * step;
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+    }
+    // Midfield horizontal
+    final midPaint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+    canvas.drawLine(
+      Offset(0, size.height / 2),
+      Offset(size.width, size.height / 2),
+      midPaint,
+    );
+    // Center ellipse
+    canvas.drawOval(
+      Rect.fromCenter(
+        center: Offset(size.width / 2, size.height / 2),
+        width: 100,
+        height: 76,
+      ),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/flutter_app/lib/core/team_center/views/widgets/daily_update_card.dart
+++ b/flutter_app/lib/core/team_center/views/widgets/daily_update_card.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import '../../../../design_tokens.dart';
 import '../../models/team_article.dart';
 
-const Color _kGold = Color(0xFFC9A256);
+// Editorial gold sourced from the design tokens
+const Color _kGold = AppColors.editorialGold;
+// Field gradient stops — visual treatment around the brand base; kept local
+// because they are blended artifacts of `brandBase`, not reusable brand colors.
 const Color _kFieldDark1 = Color(0xFF071810);
 const Color _kFieldDark2 = AppColors.brandBase; // 0xFF0F3D2E
 const Color _kFieldDark3 = Color(0xFF08221A);

--- a/flutter_app/lib/core/team_center/views/widgets/game_carousel.dart
+++ b/flutter_app/lib/core/team_center/views/widgets/game_carousel.dart
@@ -1,0 +1,603 @@
+import 'package:flutter/material.dart';
+import '../../../../micro_apps/standings/models/game_model.dart';
+import '../../../models/team_model.dart';
+import '../../../services/team_service.dart';
+
+const Color _kGold = Color(0xFFC9A256);
+const Color _kWin = Color(0xFF4CAF80);
+const Color _kLoss = Color(0xFFE06060);
+
+/// Carousel of team games. Center card = most-recent completed game,
+/// swipe right (or arrow) → older games, swipe left (or arrow) → upcoming.
+class GameCarousel extends StatefulWidget {
+  final Team team;
+  final List<Game> games;
+  final int initialIndex;
+
+  const GameCarousel({
+    super.key,
+    required this.team,
+    required this.games,
+    required this.initialIndex,
+  });
+
+  @override
+  State<GameCarousel> createState() => _GameCarouselState();
+}
+
+class _GameCarouselState extends State<GameCarousel> {
+  late int _centerIdx;
+  double _dragDelta = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _centerIdx = widget.initialIndex.clamp(0, widget.games.length - 1);
+  }
+
+  bool get _canGoLeft => _centerIdx > 0; // newer/upcoming
+  bool get _canGoRight => _centerIdx < widget.games.length - 1; // older
+
+  void _navigate(int dir) {
+    final next = _centerIdx + dir;
+    if (next >= 0 && next < widget.games.length) {
+      setState(() => _centerIdx = next);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.games.isEmpty) return const SizedBox.shrink();
+    final current = widget.games[_centerIdx];
+    final isUpcoming = !current.isPlayed;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _sectionLabel('GAMES'),
+              Text(
+                isUpcoming ? 'UPCOMING' : 'RESULT',
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.white.withValues(alpha: 0.25),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+        SizedBox(
+          height: 156,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onHorizontalDragUpdate: (d) => _dragDelta += d.delta.dx,
+            onHorizontalDragEnd: (_) {
+              if (_dragDelta < -40) {
+                _navigate(1);
+              } else if (_dragDelta > 40) {
+                _navigate(-1);
+              }
+              _dragDelta = 0;
+            },
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                ..._buildVisibleCards(),
+                Positioned(
+                  left: 4,
+                  child: _navButton(
+                    icon: Icons.chevron_left,
+                    enabled: _canGoLeft,
+                    onTap: () => _navigate(-1),
+                  ),
+                ),
+                Positioned(
+                  right: 4,
+                  child: _navButton(
+                    icon: Icons.chevron_right,
+                    enabled: _canGoRight,
+                    onTap: () => _navigate(1),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '← UPCOMING',
+                style: TextStyle(
+                  fontSize: 9,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.7,
+                  color: _kGold.withValues(alpha: 0.6),
+                ),
+              ),
+              Text(
+                'OLDER →',
+                style: TextStyle(
+                  fontSize: 9,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.7,
+                  color: Colors.white.withValues(alpha: 0.25),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+        _buildDots(),
+      ],
+    );
+  }
+
+  List<Widget> _buildVisibleCards() {
+    final cards = <Widget>[];
+    // Build outermost first so center is on top via zIndex via order.
+    for (final pos in [-2, 2, -1, 1, 0]) {
+      final idx = _centerIdx + pos;
+      if (idx < 0 || idx >= widget.games.length) continue;
+      cards.add(_buildCard(widget.games[idx], pos));
+    }
+    return cards;
+  }
+
+  Widget _buildCard(Game game, int position) {
+    final abs = position.abs();
+    final scale = abs == 0 ? 1.0 : (abs == 1 ? 0.78 : 0.64);
+    final opacity = abs == 0 ? 1.0 : (abs == 1 ? 0.72 : 0.45);
+    const cardW = 200.0;
+    const cardH = 140.0;
+    const spacing = 148.0;
+    final dx = position * spacing;
+
+    return AnimatedPositioned(
+      duration: const Duration(milliseconds: 380),
+      curve: Curves.easeOutCubic,
+      left: null,
+      right: null,
+      child: AnimatedOpacity(
+        opacity: opacity,
+        duration: const Duration(milliseconds: 380),
+        child: Transform.translate(
+          offset: Offset(dx, 0),
+          child: Transform.scale(
+            scale: scale,
+            child: GestureDetector(
+              onTap: () {
+                if (abs == 0) return;
+                _navigate(position > 0 ? 1 : -1);
+              },
+              child: SizedBox(
+                width: cardW,
+                height: cardH,
+                child: _GameCardContent(
+                  game: game,
+                  team: widget.team,
+                  isCenter: abs == 0,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _navButton({
+    required IconData icon,
+    required bool enabled,
+    required VoidCallback onTap,
+  }) {
+    return Opacity(
+      opacity: enabled ? 1.0 : 0.25,
+      child: IgnorePointer(
+        ignoring: !enabled,
+        child: GestureDetector(
+          onTap: onTap,
+          child: Container(
+            width: 30,
+            height: 30,
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.08),
+              shape: BoxShape.circle,
+              border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+            ),
+            child: Icon(icon, size: 18, color: Colors.white),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDots() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(widget.games.length, (i) {
+        final active = i == _centerIdx;
+        return GestureDetector(
+          onTap: () => setState(() => _centerIdx = i),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            margin: const EdgeInsets.symmetric(horizontal: 2.5),
+            width: active ? 16 : 5,
+            height: 5,
+            decoration: BoxDecoration(
+              color: active ? _kWin : Colors.white.withValues(alpha: 0.22),
+              borderRadius: BorderRadius.circular(3),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+
+  Widget _sectionLabel(String text) => Text(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.1,
+          color: Colors.white.withValues(alpha: 0.4),
+        ),
+      );
+}
+
+class _GameCardContent extends StatelessWidget {
+  final Game game;
+  final Team team;
+  final bool isCenter;
+
+  const _GameCardContent({
+    required this.game,
+    required this.team,
+    required this.isCenter,
+  });
+
+  bool get _teamIsHome => game.homeTeam.toUpperCase() == team.id.toUpperCase();
+
+  String get _opponentAbbr => _teamIsHome ? game.awayTeam : game.homeTeam;
+
+  Color get _opponentColor {
+    final t = TeamService()
+        .getTeams()
+        .where((x) => x.id.toUpperCase() == _opponentAbbr.toUpperCase())
+        .toList();
+    return t.isNotEmpty ? t.first.primaryColor : const Color(0xFF1F2A22);
+  }
+
+  int? get _teamScore => _teamIsHome ? game.homeScore : game.awayScore;
+  int? get _oppScore => _teamIsHome ? game.awayScore : game.homeScore;
+
+  String get _result {
+    if (!game.isPlayed) return 'U';
+    if (_teamScore! > _oppScore!) return 'W';
+    if (_teamScore! < _oppScore!) return 'L';
+    return 'T';
+  }
+
+  String _formatDate() {
+    const months = [
+      'JAN',
+      'FEB',
+      'MAR',
+      'APR',
+      'MAY',
+      'JUN',
+      'JUL',
+      'AUG',
+      'SEP',
+      'OCT',
+      'NOV',
+      'DEC',
+    ];
+    return '${months[game.gameday.month - 1]} ${game.gameday.day}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final oppColor = _opponentColor;
+    return Stack(
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(
+                  alpha: isCenter ? 0.5 : 0.3,
+                ),
+                blurRadius: isCenter ? 40 : 16,
+                offset: Offset(0, isCenter ? 12 : 4),
+              ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(18),
+            child: Stack(
+              children: [
+                // Opponent color gradient
+                Positioned.fill(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          oppColor.withValues(alpha: 0.93),
+                          oppColor.withValues(alpha: 0.53),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                // Bottom dark fade
+                Positioned.fill(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.black.withValues(alpha: 0.1),
+                          Colors.black.withValues(alpha: 0.55),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                // Content
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 12, 12, 26),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'WEEK ${game.week} · ${_teamIsHome ? "HOME" : "AWAY"}',
+                        style: TextStyle(
+                          fontSize: 9,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.9,
+                          color: Colors.white.withValues(alpha: 0.55),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Expanded(
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            _buildTeamSide(
+                              abbr: team.id.toUpperCase(),
+                              color: team.primaryColor,
+                              labelColor: Colors.white,
+                            ),
+                            _buildScoreOrTime(),
+                            _buildTeamSide(
+                              abbr: _opponentAbbr.toUpperCase(),
+                              color: oppColor,
+                              labelColor: Colors.white.withValues(alpha: 0.85),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                // Footer
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: Container(
+                    color: Colors.black.withValues(alpha: 0.25),
+                    padding: const EdgeInsets.fromLTRB(14, 6, 14, 8),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          _formatDate(),
+                          style: TextStyle(
+                            fontSize: 9,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 0.6,
+                            color: Colors.white.withValues(alpha: 0.5),
+                          ),
+                        ),
+                        if (game.stadium != null && game.stadium!.isNotEmpty)
+                          Flexible(
+                            child: Text(
+                              game.stadium!,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              textAlign: TextAlign.right,
+                              style: TextStyle(
+                                fontSize: 9,
+                                fontWeight: FontWeight.w500,
+                                color: Colors.white.withValues(alpha: 0.35),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        // Center glow
+        if (isCenter)
+          Positioned.fill(
+            child: IgnorePointer(
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(19),
+                  border: Border.all(
+                    color: _kWin.withValues(alpha: 0.5),
+                    width: 1.5,
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildTeamSide({
+    required String abbr,
+    required Color color,
+    required Color labelColor,
+  }) {
+    return Expanded(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.22),
+                width: 1.5,
+              ),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              abbr,
+              style: const TextStyle(
+                fontFamily: 'Russo One',
+                fontSize: 10,
+                color: Colors.white,
+                letterSpacing: 0.2,
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            abbr,
+            style: TextStyle(
+              fontFamily: 'Russo One',
+              fontSize: 14,
+              color: labelColor,
+              letterSpacing: 0.3,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScoreOrTime() {
+    if (!game.isPlayed) {
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            game.gametime.isNotEmpty ? game.gametime : 'TBD',
+            style: const TextStyle(
+              fontFamily: 'Russo One',
+              fontSize: 13,
+              color: _kGold,
+              letterSpacing: 0.3,
+            ),
+          ),
+          const SizedBox(height: 4),
+          _badge(
+            text: 'UPCOMING',
+            bg: _kGold.withValues(alpha: 0.2),
+            fg: _kGold,
+          ),
+        ],
+      );
+    }
+    final teamColor =
+        _result == 'W' ? _kWin : (_result == 'L' ? _kLoss : Colors.white);
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '${_teamScore ?? 0}',
+              style: TextStyle(
+                fontFamily: 'Russo One',
+                fontSize: 22,
+                color: teamColor,
+                letterSpacing: 0.7,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2),
+              child: Text(
+                '–',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white.withValues(alpha: 0.3),
+                ),
+              ),
+            ),
+            Text(
+              '${_oppScore ?? 0}',
+              style: TextStyle(
+                fontFamily: 'Russo One',
+                fontSize: 22,
+                color: Colors.white.withValues(alpha: 0.7),
+                letterSpacing: 0.7,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        _badge(
+          text: _result == 'W' ? 'WIN' : (_result == 'L' ? 'LOSS' : 'TIE'),
+          bg: _result == 'W'
+              ? _kWin.withValues(alpha: 0.25)
+              : (_result == 'L'
+                  ? _kLoss.withValues(alpha: 0.2)
+                  : Colors.white.withValues(alpha: 0.15)),
+          fg: _result == 'W' ? _kWin : (_result == 'L' ? _kLoss : Colors.white),
+        ),
+      ],
+    );
+  }
+
+  Widget _badge({required String text, required Color bg, required Color fg}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 9,
+          fontWeight: FontWeight.w800,
+          letterSpacing: 0.9,
+          color: fg,
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/core/team_center/views/widgets/team_menu_button.dart
+++ b/flutter_app/lib/core/team_center/views/widgets/team_menu_button.dart
@@ -1,12 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
+/// Team Info tile used in the Team Center overlay.
+/// Renders a colored icon block on the left, label + subtitle in the middle,
+/// and an optional ghost stat number plus chevron on the right.
 class TeamMenuButton extends StatelessWidget {
   final String label;
   final IconData icon;
   final String? iconAssetPath;
   final VoidCallback onTap;
   final Color? color;
+
+  /// Optional secondary line beneath the label (e.g. "53 active · 16 PS").
+  final String? subtitle;
+
+  /// Optional accent color for the colored left icon block.
+  /// Falls back to [color] (team color) or brand green.
+  final Color? accentColor;
+
+  /// Optional big ghost number on the right side.
+  final String? statText;
+
+  /// Optional color for the stat number (e.g. red for injuries).
+  final Color? statColor;
 
   const TeamMenuButton({
     super.key,
@@ -15,93 +31,193 @@ class TeamMenuButton extends StatelessWidget {
     this.iconAssetPath,
     required this.onTap,
     this.color,
+    this.subtitle,
+    this.accentColor,
+    this.statText,
+    this.statColor,
   });
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
+    final accent = accentColor ?? color ?? const Color(0xFF0F3D2E);
+    final accentLight = Color.lerp(accent, Colors.white, 0.18)!;
 
     return Container(
-      margin: const EdgeInsets.only(bottom: 12),
-      child: Material(
-        color: (color ?? const Color(0xFF252836))
-            .withValues(alpha: 0.9), // Team color or Dark Blue-Grey
-        borderRadius: BorderRadius.circular(20),
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(20),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              children: [
-                // Icon Container
-                Container(
-                  width: 44,
-                  height: 44,
-                  decoration: BoxDecoration(
-                    // color: const Color(0xFF38404B), // Removed per user request ("no background")
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Center(
-                    child: iconAssetPath != null
-                        ? (iconAssetPath!.toLowerCase().endsWith('.svg')
-                            ? SvgPicture.asset(
-                                iconAssetPath!,
-                                width: 28,
-                                height: 28,
-                                fit: BoxFit.contain,
-                                colorFilter: isDark
-                                    ? ColorFilter.mode(
-                                        Colors.white.withValues(alpha: 0.9),
-                                        BlendMode.srcIn,
-                                      )
-                                    : null,
-                              )
-                            : Image.asset(
-                                iconAssetPath!,
-                                width: 28,
-                                height: 28,
-                                fit: BoxFit.contain,
-                                errorBuilder: (context, error, stackTrace) {
-                                  return Icon(
-                                    icon,
-                                    color: const Color(0xFF4ADE80),
-                                    size: 24,
-                                  );
-                                },
-                              ))
-                        : Icon(
-                            icon,
-                            color: const Color(
-                                0xFF4ADE80), // Green accent from mockup
-                            size: 24,
+      margin: const EdgeInsets.only(bottom: 8),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.07)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.25),
+            blurRadius: 12,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onTap,
+            child: IntrinsicHeight(
+              child: Row(
+                children: [
+                  // Colored icon block
+                  Container(
+                    width: 64,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [accentLight, accent],
+                      ),
+                    ),
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        IgnorePointer(
+                          child: Opacity(
+                            opacity: 0.07,
+                            child: CustomPaint(
+                              size: const Size(64, 80),
+                              painter: _GridPainter(),
+                            ),
                           ),
-                  ),
-                ),
-                const SizedBox(width: 16),
-
-                // Label
-                Expanded(
-                  child: Text(
-                    label,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
+                        ),
+                        _buildIcon(),
+                      ],
                     ),
                   ),
-                ),
-
-                // Chevron
-                const Icon(
-                  Icons.chevron_right,
-                  color: Colors.white54,
-                ),
-              ],
+                  // Body
+                  Expanded(
+                    child: Container(
+                      color: const Color(0xD90F1411), // rgba(15,20,17,0.85)
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 13,
+                      ),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  label,
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w700,
+                                    fontSize: 15,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                                if (subtitle != null) ...[
+                                  const SizedBox(height: 2),
+                                  Text(
+                                    subtitle!,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w500,
+                                      color:
+                                          Colors.white.withValues(alpha: 0.38),
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                          if (statText != null) ...[
+                            const SizedBox(width: 10),
+                            Text(
+                              statText!,
+                              style: TextStyle(
+                                fontFamily: 'Russo One',
+                                fontSize: 18,
+                                color: statColor ??
+                                    Colors.white.withValues(alpha: 0.18),
+                              ),
+                            ),
+                          ],
+                          const SizedBox(width: 10),
+                          Container(
+                            width: 22,
+                            height: 22,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.white.withValues(alpha: 0.07),
+                            ),
+                            alignment: Alignment.center,
+                            child: Icon(
+                              Icons.chevron_right,
+                              size: 16,
+                              color: Colors.white.withValues(alpha: 0.35),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
     );
   }
+
+  Widget _buildIcon() {
+    if (iconAssetPath != null) {
+      if (iconAssetPath!.toLowerCase().endsWith('.svg')) {
+        return SvgPicture.asset(
+          iconAssetPath!,
+          width: 26,
+          height: 26,
+          fit: BoxFit.contain,
+          colorFilter: ColorFilter.mode(
+            Colors.white.withValues(alpha: 0.9),
+            BlendMode.srcIn,
+          ),
+        );
+      }
+      return Image.asset(
+        iconAssetPath!,
+        width: 26,
+        height: 26,
+        fit: BoxFit.contain,
+        errorBuilder: (_, __, ___) => Icon(
+          icon,
+          color: Colors.white.withValues(alpha: 0.9),
+          size: 24,
+        ),
+      );
+    }
+    return Icon(icon, color: Colors.white.withValues(alpha: 0.9), size: 24);
+  }
+}
+
+class _GridPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 1;
+    canvas.drawLine(
+      Offset(size.width / 2, 0),
+      Offset(size.width / 2, size.height),
+      paint,
+    );
+    canvas.drawLine(
+      Offset(0, size.height / 2),
+      Offset(size.width, size.height / 2),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/flutter_app/lib/design_tokens.dart
+++ b/flutter_app/lib/design_tokens.dart
@@ -34,6 +34,14 @@ class AppColors {
   static const Color breakingNewsRed = Color(0xFF991b1b); // Red-800
   static const Color breakingNewsRedBright = Color(0xFFef4444); // Red-500
 
+  // Status (player availability indicators across team center surfaces)
+  static const Color statusActive = Color(0xFF4caf80); // Green — active/healthy
+  static const Color statusQuest = Color(0xFFc9a256); // Gold — questionable
+  static const Color statusOut = Color(0xFFe06060); // Red — out / IR
+
+  // Editorial accent — used for premium/podcast highlights and starter pills
+  static const Color editorialGold = Color(0xFFc9a256);
+
   // Legacy/Mapped Colors (Restored for compatibility)
   static const Color primary = brandBase;
   static const Color secondary = brandLight;

--- a/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
+++ b/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
@@ -215,7 +215,6 @@ class _BreakingNewsDetailScreenState extends State<BreakingNewsDetailScreen> {
       ),
     );
   }
-
 }
 
 // ─── Hero ────────────────────────────────────────────────────────────

--- a/flutter_app/lib/micro_apps/radio/controllers/radio_controller.dart
+++ b/flutter_app/lib/micro_apps/radio/controllers/radio_controller.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:tackle4loss_mobile/core/services/audio_player_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';

--- a/flutter_app/lib/micro_apps/radio/views/widgets/radio_home_widget.dart
+++ b/flutter_app/lib/micro_apps/radio/views/widgets/radio_home_widget.dart
@@ -67,6 +67,7 @@ class _RadioHomeWidgetState extends State<RadioHomeWidget>
     if (!mounted || !_scrollController.hasClients) return;
 
     final maxScroll = _scrollController.position.maxScrollExtent;
+    // ignore: deprecated_member_use
     final tickerEnabled = TickerMode.of(context);
     final shouldRun = tickerEnabled && maxScroll > 0;
 

--- a/flutter_app/test/micro_apps/radio/controllers/radio_controller_test.dart
+++ b/flutter_app/test/micro_apps/radio/controllers/radio_controller_test.dart
@@ -29,8 +29,8 @@ class MockAudioPlayerService extends AudioPlayerService {
 class MockHttpClient extends Mock implements http.Client {}
 
 class TestRadioController extends RadioController {
-  TestRadioController(this.tracks, {AudioPlayerService? audioService})
-      : super(languageCode: 'en', audioService: audioService);
+  TestRadioController(this.tracks, {super.audioService})
+      : super(languageCode: 'en');
 
   final List<Map<String, String>> tracks;
 

--- a/web/design-tokens.ts
+++ b/web/design-tokens.ts
@@ -32,6 +32,16 @@ export const designTokens = {
       breakingNewsRed: '#991b1b',
       breakingNewsRedBright: '#ef4444',
     },
+    // Player availability indicators (team center surfaces)
+    status: {
+      active: '#4caf80', // healthy / active
+      quest: '#c9a256', // questionable
+      out: '#e06060', // out / IR
+    },
+    // Editorial accent — used for podcast/premium chips and starter pills
+    editorial: {
+      gold: '#c9a256',
+    },
   },
   typography: {
     fontFamilies: {


### PR DESCRIPTION
## Summary
Implements the Claude Design handoff for the Team Center sheet (`Team Center.html`).

- **Daily Update card** — field-line backdrop, animated gold "Daily Update" chip, Russo One headline, animated gold waveform, gold progress bar, and pulsing white play button.
- **Game Carousel (new)** — 5-card stack centered on the most-recent completed game, with chevron nav, swipe gestures, dot indicators, and "← Upcoming / Older →" labels. Cards adopt the opponent's primary color and show W/L badges or a gold `UPCOMING` chip for future games.
- **Team Info tiles** — colored left icon blocks (brand green / navy / dark red), live subtitles (roster size, injury breakdown), ghost Russo One stat numerals, and chevron pill.
- Overlay eagerly loads injuries so tile stats render on open.

## Test plan
- [ ] `flutter analyze --fatal-warnings lib/core/team_center` (passes locally)
- [ ] `dart format --set-exit-if-changed lib/core/team_center` (clean locally)
- [ ] Open Team Center for several teams; confirm carousel centers on most-recent played game and navigates to past/upcoming
- [ ] Verify Daily Update animations (chip pulse, waveform, play-button glow) on a real device
- [ ] Verify roster + injury subtitles populate after data loads
- [ ] Visual QA on iOS + Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)