### PR TITLE
feat(flutter): redesign team roster screen

### DIFF
--- a/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
+++ b/flutter_app/lib/core/os_shell/widgets/news_feed/breaking_list_item_card.dart
@@ -211,9 +211,8 @@ class _MarqueeTextState extends State<_MarqueeText>
         child: AnimatedBuilder(
           animation: _ctrl,
           builder: (_, __) {
-            final t = (_ctrl.lastElapsedDuration?.inMicroseconds ?? 0) /
-                1e6 %
-                period;
+            final t =
+                (_ctrl.lastElapsedDuration?.inMicroseconds ?? 0) / 1e6 % period;
             final dx = -_MarqueeText._pixelsPerSecond * t;
             return Stack(
               clipBehavior: Clip.none,

--- a/flutter_app/lib/core/team_center/views/team_roster_screen.dart
+++ b/flutter_app/lib/core/team_center/views/team_roster_screen.dart
@@ -3,9 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../models/team_model.dart';
-import '../../theme/t4l_theme.dart';
 import '../models/roster_player.dart';
 import '../controllers/team_center_controller.dart';
+
+const Color _kSheetBgSurface = Color(0xF20E1410); // 0.95
+const Color _kBorderSoft = Color(0x12FFFFFF);
+const Color _kChipActive = Color(0xFF0F3D2E);
+const Color _kAccentBadge = Color(0xFF0F3D2E);
 
 class TeamRosterScreen extends StatefulWidget {
   final Team team;
@@ -21,187 +25,110 @@ class TeamRosterScreen extends StatefulWidget {
   State<TeamRosterScreen> createState() => _TeamRosterScreenState();
 }
 
-class _TeamRosterScreenState extends State<TeamRosterScreen>
-    with SingleTickerProviderStateMixin {
-  late TabController _tabController;
-  final List<String> _tabs = ['OFFENSE', 'DEFENSE', 'SPECIAL TEAMS'];
+class _TeamRosterScreenState extends State<TeamRosterScreen> {
+  static const _units = ['OFFENSE', 'DEFENSE', 'SPECIAL'];
+
+  int _unitIdx = 1; // Defense default — matches existing app behavior
+  String _posFilter = 'ALL';
+  String _query = '';
+  final TextEditingController _searchCtl = TextEditingController();
+  final FocusNode _searchFocus = FocusNode();
 
   @override
   void initState() {
     super.initState();
-    _tabController =
-        TabController(length: _tabs.length, vsync: this, initialIndex: 1);
-
-    // Load roster data when screen opens (safe due to controller check)
     WidgetsBinding.instance.addPostFrameCallback((_) {
       widget.controller.loadTeamRoster(widget.team.id);
-
-      // Preload Offense and Special Teams since Defense was preloaded in Overlay
       _preloadImages(widget.controller.offenseRoster);
       _preloadImages(widget.controller.specialTeamsRoster);
     });
   }
 
+  @override
+  void dispose() {
+    _searchCtl.dispose();
+    _searchFocus.dispose();
+    super.dispose();
+  }
+
   void _preloadImages(List<RosterPlayer> players) {
     if (!mounted) return;
-    for (final player in players) {
-      precacheImage(CachedNetworkImageProvider(player.imageUrl), context);
+    for (final p in players) {
+      if (p.imageUrl.isNotEmpty) {
+        precacheImage(CachedNetworkImageProvider(p.imageUrl), context);
+      }
+    }
+  }
+
+  void _switchUnit(int idx) {
+    setState(() {
+      _unitIdx = idx;
+      _posFilter = 'ALL';
+      _query = '';
+      _searchCtl.clear();
+    });
+  }
+
+  List<RosterPlayer> _unitRoster(TeamCenterController c) {
+    switch (_unitIdx) {
+      case 0:
+        return c.offenseRoster;
+      case 2:
+        return c.specialTeamsRoster;
+      default:
+        return c.defenseRoster;
     }
   }
 
   @override
-  void dispose() {
-    _tabController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).extension<T4LThemeColors>()!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
     return ChangeNotifierProvider.value(
-        value: widget.controller,
-        child: Scaffold(
-          backgroundColor: Colors.transparent, // Transparent for blur to work
-          body: Stack(
-            children: [
-              // Background Blur (same as TeamCenterOverlay)
-              Positioned.fill(
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-                  child: Container(color: Colors.transparent),
-                ),
-              ),
-
-              // Gradient overlay
-              Positioned.fill(
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        widget.team.primaryColor.withValues(alpha: 0.15),
-                        colors.background.withValues(alpha: 0.0),
-                      ],
-                      stops: const [0.0, 0.4],
-                    ),
-                  ),
-                ),
-              ),
-
-              SafeArea(
-                child: Column(
-                  children: [
-                    // 1. Header
-                    _buildHeader(colors),
-
-                    // 2. Tabs
-                    Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 24, vertical: 16),
-                      child: _buildSegmentedControl(colors, isDark),
-                    ),
-
-                    // 3. Tab Bar View (Lists)
-                    Expanded(
-                      child: Consumer<TeamCenterController>(
-                        builder: (context, controller, child) {
-                          if (controller.isRosterLoading) {
-                            return const Center(
-                                child: CircularProgressIndicator());
-                          }
-
-                          if (controller.rosterError != null) {
-                            return Center(
-                              child: Text(
-                                'Failed to load roster',
-                                style: TextStyle(color: colors.textMuted),
-                              ),
-                            );
-                          }
-
-                          return TabBarView(
-                            controller: _tabController,
-                            children: [
-                              _buildRosterList(
-                                  controller.offenseRoster, colors),
-                              _buildRosterList(
-                                  controller.defenseRoster, colors),
-                              _buildRosterList(
-                                  controller.specialTeamsRoster, colors),
-                            ],
-                          );
-                        },
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ));
-  }
-
-  Widget _buildHeader(T4LThemeColors colors) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-      child: SizedBox(
-        width: double.infinity,
-        child: Stack(
-          alignment: Alignment.center,
+      value: widget.controller,
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Stack(
           children: [
-            // Centered Title
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Container(
-                  width: 32,
-                  height: 32,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: colors.surface.withValues(alpha: 0.2),
-                    border:
-                        Border.all(color: colors.border.withValues(alpha: 0.5)),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(5),
-                    child: Image.asset(
-                      widget.team.logoUrl,
-                      errorBuilder: (_, __, ___) => Icon(Icons.shield,
-                          color: colors.textPrimary, size: 16),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 10),
-                Text(
-                  'TEAM ROSTER',
-                  style: TextStyle(
-                    fontFamily: 'Outfit',
-                    fontWeight: FontWeight.w900,
-                    fontStyle: FontStyle.italic,
-                    fontSize: 22,
-                    color: colors.textPrimary.withValues(alpha: 0.9),
-                    letterSpacing: -0.5,
-                  ),
-                ),
-              ],
+            Positioned.fill(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+                child: Container(color: Colors.transparent),
+              ),
             ),
-
-            // Close Button
-            Positioned(
-              right: 0,
-              child: IconButton(
-                onPressed: () => Navigator.of(context).pop(),
-                icon: Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: colors.surface.withValues(alpha: 0.3),
-                    shape: BoxShape.circle,
+            const Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    center: Alignment(-0.4, -0.2),
+                    radius: 1.1,
+                    colors: [Color(0xFF1A4A32), Color(0xFF0B1810)],
+                    stops: [0.0, 0.7],
                   ),
-                  child: Icon(Icons.close, color: colors.textPrimary, size: 20),
                 ),
+              ),
+            ),
+            Positioned.fill(
+              child: Container(color: _kSheetBgSurface),
+            ),
+            SafeArea(
+              child: Consumer<TeamCenterController>(
+                builder: (context, controller, _) {
+                  final players = _unitRoster(controller);
+                  final positions = _orderedPositions(players);
+                  final filtered = _filter(players);
+
+                  return Column(
+                    children: [
+                      _buildHeader(),
+                      _buildUnitTabs(),
+                      _buildSearchRow(),
+                      _buildChipsRow(positions),
+                      const SizedBox(height: 4),
+                      Expanded(
+                        child: _buildBody(controller, filtered),
+                      ),
+                    ],
+                  );
+                },
               ),
             ),
           ],
@@ -210,200 +137,876 @@ class _TeamRosterScreenState extends State<TeamRosterScreen>
     );
   }
 
-  Widget _buildSegmentedControl(T4LThemeColors colors, bool isDark) {
+  // ── HEADER ───────────────────────────────────────────────────────────────
+  Widget _buildHeader() {
     return Container(
-      height: 48,
-      decoration: BoxDecoration(
-        color: colors.surface.withValues(alpha: 0.5),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: colors.border.withValues(alpha: 0.3)),
+      padding: const EdgeInsets.fromLTRB(20, 18, 16, 14),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: _kBorderSoft)),
       ),
-      child: TabBar(
-        controller: _tabController,
-        indicator: BoxDecoration(
-          color: widget.team.primaryColor,
-          borderRadius: BorderRadius.circular(24),
-        ),
-        indicatorSize: TabBarIndicatorSize.tab,
-        dividerColor: Colors.transparent,
-        labelColor: Colors.white, // Always white on brand-colored pill
-        unselectedLabelColor: colors.textSecondary,
-        labelStyle: const TextStyle(
-          fontFamily: 'Inter',
-          fontWeight: FontWeight.bold,
-          fontSize: 12,
-        ),
-        tabs: _tabs.map((t) => Tab(text: t)).toList(),
-      ),
-    );
-  }
-
-  Widget _buildRosterList(List<RosterPlayer> players, T4LThemeColors colors) {
-    return ListView.separated(
-      padding: const EdgeInsets.all(24),
-      itemCount: players.length,
-      separatorBuilder: (_, __) => const SizedBox(height: 12),
-      itemBuilder: (context, index) {
-        final player = players[index];
-        return _buildPlayerCard(player, colors);
-      },
-    );
-  }
-
-  Widget _buildPlayerCard(RosterPlayer player, T4LThemeColors colors) {
-    // Split name for formatting if possible
-    final names = player.name.split(' ');
-    final firstName = names.isNotEmpty ? names.first : '';
-    final surname = names.length > 1 ? names.sublist(1).join(' ') : '';
-    final displayName = names.length > 1 ? '$firstName\n$surname' : player.name;
-
-    return Container(
-      height: 72,
-      decoration: BoxDecoration(
-        color: colors.surface
-            .withValues(alpha: 0.95), // More opaque for visibility
-        borderRadius: BorderRadius.circular(36),
-        border: Border.all(color: colors.border.withValues(alpha: 0.4)),
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 8),
       child: Row(
         children: [
-          // Avatar with Caching
-          CachedNetworkImage(
-            imageUrl: player.imageUrl,
-            imageBuilder: (context, imageProvider) => Container(
-              width: 56,
-              height: 56,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                image: DecorationImage(
-                  image: imageProvider,
-                  fit: BoxFit.cover,
-                ),
-                border: Border.all(color: colors.border.withValues(alpha: 0.5)),
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: widget.team.primaryColor,
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.15),
+                width: 2,
               ),
             ),
-            placeholder: (context, url) => Container(
-              width: 56,
-              height: 56,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: colors.surface.withValues(alpha: 0.5),
-                border: Border.all(color: colors.border.withValues(alpha: 0.5)),
-              ),
-              child: Center(
-                child: SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator(
-                      strokeWidth: 2, color: widget.team.primaryColor),
-                ),
-              ),
-            ),
-            errorWidget: (context, url, error) => Container(
-              width: 56,
-              height: 56,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: colors.surface,
-                border: Border.all(color: colors.border.withValues(alpha: 0.5)),
-              ),
-              child: Icon(Icons.person, color: colors.textSecondary),
-            ),
-          ),
-
-          const SizedBox(width: 12),
-
-          // Name & Number
-          Expanded(
-            flex: 4,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  displayName,
-                  style: TextStyle(
-                    color: colors.textPrimary,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 14,
-                    height: 1.1,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  player.number,
-                  style: TextStyle(
-                    color: widget.team.primaryColor,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 11,
+            alignment: Alignment.center,
+            child: Padding(
+              padding: const EdgeInsets.all(5),
+              child: Image.asset(
+                widget.team.logoUrl,
+                errorBuilder: (_, __, ___) => Text(
+                  widget.team.id.toUpperCase(),
+                  style: const TextStyle(
+                    fontFamily: 'Russo One',
+                    fontSize: 9,
+                    color: Colors.white,
+                    letterSpacing: 0.4,
                   ),
                 ),
-              ],
-            ),
-          ),
-
-          // Position
-          Expanded(
-            flex: 1,
-            child: Center(
-              child: Container(
-                constraints: const BoxConstraints(minWidth: 32),
-                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-                decoration: BoxDecoration(
-                  color: colors.surface.withValues(alpha: 0.6),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Text(
-                  player.position,
-                  style: TextStyle(
-                    color: colors.textPrimary,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 11,
-                  ),
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  softWrap: false,
-                ),
               ),
             ),
           ),
-
-          // Experience
-          Expanded(
-            flex: 1,
-            child: Text(
-              player.experience,
-              style: TextStyle(
-                color: colors.textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w500,
-              ),
-              textAlign: TextAlign.center,
+          const SizedBox(width: 10),
+          const Text(
+            'TEAM ROSTER',
+            style: TextStyle(
+              fontFamily: 'Russo One',
+              fontSize: 20,
+              fontStyle: FontStyle.italic,
+              letterSpacing: 0.8,
+              color: Colors.white,
             ),
           ),
-
-          // College
-          Expanded(
-            flex: 2,
-            child: Text(
-              player.college.toUpperCase(),
-              style: TextStyle(
-                color: colors.textSecondary,
-                fontSize: 11,
-                fontWeight: FontWeight.bold,
-                letterSpacing: 0.5,
+          const Spacer(),
+          GestureDetector(
+            onTap: () => Navigator.of(context).pop(),
+            child: Container(
+              width: 30,
+              height: 30,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withValues(alpha: 0.08),
               ),
-              textAlign: TextAlign.right,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+              alignment: Alignment.center,
+              child: Icon(
+                Icons.close,
+                size: 14,
+                color: Colors.white.withValues(alpha: 0.6),
+              ),
             ),
           ),
-
-          const SizedBox(width: 16),
         ],
+      ),
+    );
+  }
+
+  // ── UNIT TABS ────────────────────────────────────────────────────────────
+  Widget _buildUnitTabs() {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: _kBorderSoft)),
+      ),
+      child: Row(
+        children: List.generate(_units.length, (i) {
+          final active = i == _unitIdx;
+          return Expanded(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _switchUnit(i),
+              child: Container(
+                padding: const EdgeInsets.fromLTRB(4, 8, 4, 10),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: active ? _kAccentBadge : Colors.transparent,
+                      width: 2,
+                    ),
+                  ),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  _units[i],
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.99,
+                    color: active
+                        ? Colors.white
+                        : Colors.white.withValues(alpha: 0.35),
+                  ),
+                ),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  // ── SEARCH ROW ───────────────────────────────────────────────────────────
+  Widget _buildSearchRow() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: _searchFocus.hasFocus
+                ? _kAccentBadge.withValues(alpha: 0.6)
+                : Colors.white.withValues(alpha: 0.07),
+          ),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              Icons.search,
+              size: 16,
+              color: Colors.white.withValues(alpha: 0.3),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: TextField(
+                controller: _searchCtl,
+                focusNode: _searchFocus,
+                onChanged: (v) => setState(() => _query = v),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                ),
+                decoration: InputDecoration(
+                  isDense: true,
+                  contentPadding: EdgeInsets.zero,
+                  border: InputBorder.none,
+                  hintText: 'Search players, position, college…',
+                  hintStyle: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.25),
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ),
+            if (_query.isNotEmpty)
+              GestureDetector(
+                onTap: () {
+                  _searchCtl.clear();
+                  setState(() => _query = '');
+                  _searchFocus.requestFocus();
+                },
+                child: Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Colors.white.withValues(alpha: 0.15),
+                  ),
+                  alignment: Alignment.center,
+                  child: Icon(
+                    Icons.close,
+                    size: 10,
+                    color: Colors.white.withValues(alpha: 0.6),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ── CHIPS ────────────────────────────────────────────────────────────────
+  Widget _buildChipsRow(List<String> positions) {
+    final chips = ['ALL', ...positions];
+    return SizedBox(
+      height: 38,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+        itemCount: chips.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 6),
+        itemBuilder: (_, i) {
+          final c = chips[i];
+          final active = c == _posFilter;
+          return GestureDetector(
+            onTap: () => setState(() => _posFilter = c),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+              decoration: BoxDecoration(
+                color: active
+                    ? _kChipActive
+                    : Colors.white.withValues(alpha: 0.05),
+                borderRadius: BorderRadius.circular(999),
+                border: Border.all(
+                  color: active
+                      ? _kChipActive
+                      : Colors.white.withValues(alpha: 0.1),
+                ),
+              ),
+              alignment: Alignment.center,
+              child: Text(
+                c,
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.77,
+                  color: active
+                      ? Colors.white
+                      : Colors.white.withValues(alpha: 0.45),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  // ── LIST ─────────────────────────────────────────────────────────────────
+  Widget _buildBody(TeamCenterController c, List<RosterPlayer> filtered) {
+    if (c.isRosterLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (c.rosterError != null) {
+      return Center(
+        child: Text(
+          'Failed to load roster',
+          style: TextStyle(color: Colors.white.withValues(alpha: 0.45)),
+        ),
+      );
+    }
+    if (filtered.isEmpty) return _buildEmpty();
+
+    final groups = _groupByPosition(filtered);
+
+    return CustomScrollView(
+      slivers: [
+        for (final g in groups) ...[
+          SliverPersistentHeader(
+            pinned: true,
+            delegate: _GroupHeaderDelegate(
+              label: _positionLabel(g.position),
+              count: g.players.length,
+            ),
+          ),
+          SliverList.separated(
+            itemCount: g.players.length,
+            itemBuilder: (_, i) => _buildPlayerRow(g.players[i]),
+            separatorBuilder: (_, __) => const Padding(
+              padding: EdgeInsets.only(left: 72, right: 16),
+              child: Divider(
+                height: 1,
+                thickness: 1,
+                color: Color(0x0AFFFFFF),
+              ),
+            ),
+          ),
+        ],
+        const SliverToBoxAdapter(child: SizedBox(height: 24)),
+      ],
+    );
+  }
+
+  Widget _buildEmpty() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.search_off,
+            size: 40,
+            color: Colors.white.withValues(alpha: 0.15),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'No players found',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.4),
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Try a different search or filter',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.3),
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── PLAYER ROW ───────────────────────────────────────────────────────────
+  Widget _buildPlayerRow(RosterPlayer p) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () => _showPlayerDetail(p),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 26,
+                child: Text(
+                  _formatNumber(p.number),
+                  textAlign: TextAlign.right,
+                  style: TextStyle(
+                    fontFamily: 'Russo One',
+                    fontSize: 15,
+                    color: Colors.white.withValues(alpha: 0.25),
+                    letterSpacing: 0.3,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              _buildAvatar(p),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      p.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        height: 1.2,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: _kAccentBadge.withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            p.position.toUpperCase(),
+                            style: TextStyle(
+                              fontSize: 9,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: 0.72,
+                              color: Colors.white.withValues(alpha: 0.7),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    if ((p.experience.isNotEmpty &&
+                            p.experience.trim() != '—') ||
+                        (p.college.isNotEmpty && p.college != 'N/A')) ...[
+                      const SizedBox(height: 3),
+                      Text(
+                        _metaLine(p),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 10,
+                          fontWeight: FontWeight.w500,
+                          color: Colors.white.withValues(alpha: 0.32),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: Colors.white.withValues(alpha: 0.18),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAvatar(RosterPlayer p) {
+    final fallbackBg = _positionAccent(p.position);
+    final initials = _initials(p.name);
+    return Container(
+      width: 42,
+      height: 42,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: Colors.white.withValues(alpha: 0.12),
+          width: 2,
+        ),
+      ),
+      child: ClipOval(
+        child: p.imageUrl.isNotEmpty
+            ? CachedNetworkImage(
+                imageUrl: p.imageUrl,
+                fit: BoxFit.cover,
+                placeholder: (_, __) => Container(
+                  color: fallbackBg,
+                  alignment: Alignment.center,
+                  child: Text(
+                    initials,
+                    style: TextStyle(
+                      fontFamily: 'Russo One',
+                      fontSize: 13,
+                      color: Colors.white.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ),
+                errorWidget: (_, __, ___) => Container(
+                  color: fallbackBg,
+                  alignment: Alignment.center,
+                  child: Text(
+                    initials,
+                    style: TextStyle(
+                      fontFamily: 'Russo One',
+                      fontSize: 13,
+                      color: Colors.white.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ),
+              )
+            : Container(
+                color: fallbackBg,
+                alignment: Alignment.center,
+                child: Text(
+                  initials,
+                  style: TextStyle(
+                    fontFamily: 'Russo One',
+                    fontSize: 13,
+                    color: Colors.white.withValues(alpha: 0.7),
+                  ),
+                ),
+              ),
+      ),
+    );
+  }
+
+  // ── DETAIL SHEET ─────────────────────────────────────────────────────────
+  void _showPlayerDetail(RosterPlayer p) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      barrierColor: Colors.black.withValues(alpha: 0.5),
+      builder: (_) => _PlayerDetailSheet(player: p, team: widget.team),
+    );
+  }
+
+  // ── HELPERS ──────────────────────────────────────────────────────────────
+  List<RosterPlayer> _filter(List<RosterPlayer> players) {
+    final q = _query.trim().toLowerCase();
+    return players.where((p) {
+      final matchPos = _posFilter == 'ALL' || p.position == _posFilter;
+      if (!matchPos) return false;
+      if (q.isEmpty) return true;
+      return p.name.toLowerCase().contains(q) ||
+          p.position.toLowerCase().contains(q) ||
+          p.college.toLowerCase().contains(q);
+    }).toList();
+  }
+
+  List<String> _orderedPositions(List<RosterPlayer> players) {
+    final seen = <String>{};
+    final ordered = <String>[];
+    for (final p in players) {
+      if (p.position.isEmpty) continue;
+      if (seen.add(p.position)) ordered.add(p.position);
+    }
+    ordered.sort((a, b) {
+      final aOrder = _positionOrder(a);
+      final bOrder = _positionOrder(b);
+      if (aOrder != bOrder) return aOrder.compareTo(bOrder);
+      return a.compareTo(b);
+    });
+    return ordered;
+  }
+
+  List<_PositionGroup> _groupByPosition(List<RosterPlayer> players) {
+    final map = <String, List<RosterPlayer>>{};
+    for (final p in players) {
+      map.putIfAbsent(p.position, () => []).add(p);
+    }
+    final positions = map.keys.toList()
+      ..sort((a, b) {
+        final aOrder = _positionOrder(a);
+        final bOrder = _positionOrder(b);
+        if (aOrder != bOrder) return aOrder.compareTo(bOrder);
+        return a.compareTo(b);
+      });
+    return [
+      for (final pos in positions)
+        _PositionGroup(position: pos, players: map[pos]!),
+    ];
+  }
+
+  int _positionOrder(String pos) {
+    const order = [
+      // offense
+      'QB', 'RB', 'FB', 'WR', 'TE',
+      'LT', 'LG', 'C', 'RG', 'RT', 'OL', 'T', 'G',
+      // defense
+      'DE', 'DT', 'NT', 'EDGE', 'DL',
+      'LB', 'ILB', 'OLB', 'MLB',
+      'CB', 'NB', 'S', 'FS', 'SS', 'DB',
+      // special
+      'K', 'P', 'LS', 'KR', 'PR',
+    ];
+    final idx = order.indexOf(pos.toUpperCase());
+    return idx >= 0 ? idx : 999;
+  }
+
+  String _positionLabel(String pos) {
+    const map = {
+      'QB': 'Quarterback',
+      'RB': 'Running Back',
+      'FB': 'Fullback',
+      'WR': 'Wide Receiver',
+      'TE': 'Tight End',
+      'LT': 'Left Tackle',
+      'RT': 'Right Tackle',
+      'LG': 'Left Guard',
+      'RG': 'Right Guard',
+      'C': 'Center',
+      'OL': 'Offensive Line',
+      'T': 'Tackle',
+      'G': 'Guard',
+      'DE': 'Defensive End',
+      'DT': 'Defensive Tackle',
+      'NT': 'Nose Tackle',
+      'EDGE': 'Edge',
+      'DL': 'Defensive Line',
+      'LB': 'Linebacker',
+      'ILB': 'Inside Linebacker',
+      'OLB': 'Outside Linebacker',
+      'MLB': 'Middle Linebacker',
+      'CB': 'Cornerback',
+      'NB': 'Nickel Back',
+      'S': 'Safety',
+      'FS': 'Free Safety',
+      'SS': 'Strong Safety',
+      'DB': 'Defensive Back',
+      'K': 'Kicker',
+      'P': 'Punter',
+      'LS': 'Long Snapper',
+      'KR': 'Kick Returner',
+      'PR': 'Punt Returner',
+    };
+    return map[pos.toUpperCase()] ?? pos.toUpperCase();
+  }
+
+  Color _positionAccent(String pos) {
+    const offense = ['QB', 'RB', 'FB', 'WR', 'TE'];
+    const oline = ['LT', 'RT', 'LG', 'RG', 'C', 'OL', 'T', 'G'];
+    const dline = ['DE', 'DT', 'NT', 'EDGE', 'DL'];
+    const lb = ['LB', 'ILB', 'OLB', 'MLB'];
+    const db = ['CB', 'NB', 'S', 'FS', 'SS', 'DB'];
+    final p = pos.toUpperCase();
+    if (offense.contains(p)) return const Color(0xFF1A2F4A);
+    if (oline.contains(p)) return const Color(0xFF1A2F1A);
+    if (dline.contains(p)) return const Color(0xFF2A1A1A);
+    if (lb.contains(p)) return const Color(0xFF2A1F10);
+    if (db.contains(p)) return const Color(0xFF1A2A2A);
+    return const Color(0xFF1A2A20);
+  }
+
+  String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+'));
+    final letters = parts.where((p) => p.isNotEmpty).map((p) => p[0]).toList();
+    return letters.take(2).join().toUpperCase();
+  }
+
+  String _formatNumber(String num) {
+    if (num.isEmpty) return '#';
+    return num.startsWith('#') ? num : '#$num';
+  }
+
+  String _metaLine(RosterPlayer p) {
+    final parts = <String>[];
+    final exp = p.experience.trim();
+    if (exp.isNotEmpty && exp != '—') parts.add(exp);
+    if (p.college.isNotEmpty && p.college != 'N/A') parts.add(p.college);
+    return parts.join(' · ');
+  }
+}
+
+// ─── POSITION GROUP MODEL ────────────────────────────────────────────────────
+class _PositionGroup {
+  final String position;
+  final List<RosterPlayer> players;
+  _PositionGroup({required this.position, required this.players});
+}
+
+// ─── STICKY GROUP HEADER ─────────────────────────────────────────────────────
+class _GroupHeaderDelegate extends SliverPersistentHeaderDelegate {
+  final String label;
+  final int count;
+
+  _GroupHeaderDelegate({required this.label, required this.count});
+
+  @override
+  double get minExtent => 36;
+  @override
+  double get maxExtent => 36;
+
+  @override
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+        child: Container(
+          color: const Color(0xF80E1410),
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
+          alignment: Alignment.centerLeft,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                label.toUpperCase(),
+                style: TextStyle(
+                  fontFamily: 'Russo One',
+                  fontSize: 11,
+                  letterSpacing: 1.1,
+                  color: Colors.white.withValues(alpha: 0.4),
+                ),
+              ),
+              Text(
+                '$count',
+                style: TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.5,
+                  color: Colors.white.withValues(alpha: 0.25),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant _GroupHeaderDelegate oldDelegate) {
+    return oldDelegate.label != label || oldDelegate.count != count;
+  }
+}
+
+// ─── PLAYER DETAIL SHEET ─────────────────────────────────────────────────────
+class _PlayerDetailSheet extends StatelessWidget {
+  final RosterPlayer player;
+  final Team team;
+
+  const _PlayerDetailSheet({required this.player, required this.team});
+
+  @override
+  Widget build(BuildContext context) {
+    final initials = player.name
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((p) => p.isNotEmpty)
+        .map((p) => p[0])
+        .take(2)
+        .join()
+        .toUpperCase();
+
+    final bioRows = <List<String>>[];
+    if (player.position.isNotEmpty) bioRows.add(['Position', player.position]);
+    if (player.experience.trim().isNotEmpty &&
+        player.experience.trim() != '—') {
+      bioRows.add(['Experience', player.experience]);
+    }
+    if (player.college.isNotEmpty && player.college != 'N/A') {
+      bioRows.add(['College', player.college]);
+    }
+    bioRows.add(['Team', team.id.toUpperCase()]);
+
+    return Container(
+      decoration: const BoxDecoration(
+        color: Color(0xFF141E16),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+        border: Border(
+          top: BorderSide(color: Color(0x14FFFFFF)),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(top: 12),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 14),
+              child: Row(
+                children: [
+                  Container(
+                    width: 54,
+                    height: 54,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: Colors.white.withValues(alpha: 0.2),
+                        width: 2,
+                      ),
+                    ),
+                    child: ClipOval(
+                      child: player.imageUrl.isNotEmpty
+                          ? CachedNetworkImage(
+                              imageUrl: player.imageUrl,
+                              fit: BoxFit.cover,
+                              errorWidget: (_, __, ___) => _initialsBg(
+                                initials,
+                                team.primaryColor,
+                              ),
+                            )
+                          : _initialsBg(initials, team.primaryColor),
+                    ),
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          player.name,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontFamily: 'Russo One',
+                            fontSize: 18,
+                            color: Colors.white,
+                            letterSpacing: 0.36,
+                          ),
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          [
+                            player.position,
+                            if (player.experience.trim().isNotEmpty &&
+                                player.experience.trim() != '—')
+                              '${player.experience} Exp',
+                            if (player.college.isNotEmpty &&
+                                player.college != 'N/A')
+                              player.college,
+                          ].join(' · '),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w500,
+                            color: Colors.white.withValues(alpha: 0.4),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    player.number.startsWith('#')
+                        ? player.number
+                        : '#${player.number}',
+                    style: TextStyle(
+                      fontFamily: 'Russo One',
+                      fontSize: 32,
+                      color: Colors.white.withValues(alpha: 0.1),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1, color: Color(0x0DFFFFFF)),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 14, 20, 24),
+              child: Column(
+                children: [
+                  for (int i = 0; i < bioRows.length; i++) ...[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 5),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            bioRows[i][0].toUpperCase(),
+                            style: TextStyle(
+                              fontSize: 11,
+                              fontWeight: FontWeight.w700,
+                              letterSpacing: 0.66,
+                              color: Colors.white.withValues(alpha: 0.28),
+                            ),
+                          ),
+                          Flexible(
+                            child: Text(
+                              bioRows[i][1],
+                              textAlign: TextAlign.right,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w600,
+                                color: Colors.white.withValues(alpha: 0.75),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (i < bioRows.length - 1)
+                      const Divider(height: 1, color: Color(0x0DFFFFFF)),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _initialsBg(String initials, Color color) {
+    return Container(
+      color: color,
+      alignment: Alignment.center,
+      child: Text(
+        initials,
+        style: const TextStyle(
+          fontFamily: 'Russo One',
+          fontSize: 16,
+          color: Colors.white,
+        ),
       ),
     );
   }

--- a/flutter_app/lib/core/team_center/views/team_roster_screen.dart
+++ b/flutter_app/lib/core/team_center/views/team_roster_screen.dart
@@ -2,14 +2,15 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../../../design_tokens.dart';
 import '../../models/team_model.dart';
+import '../../services/settings_service.dart';
+import '../../theme/t4l_theme.dart';
 import '../models/roster_player.dart';
 import '../controllers/team_center_controller.dart';
 
-const Color _kSheetBgSurface = Color(0xF20E1410); // 0.95
-const Color _kBorderSoft = Color(0x12FFFFFF);
-const Color _kChipActive = Color(0xFF0F3D2E);
-const Color _kAccentBadge = Color(0xFF0F3D2E);
+// Brand-green accent shared by chips/tabs (sourced from design tokens).
+const Color _kAccent = AppColors.brandBase;
 
 class TeamRosterScreen extends StatefulWidget {
   final Team team;
@@ -33,6 +34,8 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
   String _query = '';
   final TextEditingController _searchCtl = TextEditingController();
   final FocusNode _searchFocus = FocusNode();
+
+  late _RosterPalette _p;
 
   @override
   void initState() {
@@ -82,56 +85,47 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.extension<T4LThemeColors>()!;
+    final isDark = theme.brightness == Brightness.dark;
+    final settings = Provider.of<SettingsService>(context);
+    _p = _RosterPalette.from(colors, isDark);
+
     return ChangeNotifierProvider.value(
       value: widget.controller,
       child: Scaffold(
         backgroundColor: Colors.transparent,
-        body: Stack(
-          children: [
-            Positioned.fill(
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-                child: Container(color: Colors.transparent),
-              ),
-            ),
-            const Positioned.fill(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: RadialGradient(
-                    center: Alignment(-0.4, -0.2),
-                    radius: 1.1,
-                    colors: [Color(0xFF1A4A32), Color(0xFF0B1810)],
-                    stops: [0.0, 0.7],
-                  ),
+        body: Container(
+          decoration: BoxDecoration(gradient: settings.backgroundGradient),
+          child: Stack(
+            children: [
+              // Subtle scrim so chrome stays readable on bright team gradients
+              // without hiding the team color.
+              Positioned.fill(child: Container(color: _p.scrim)),
+              SafeArea(
+                child: Consumer<TeamCenterController>(
+                  builder: (context, controller, _) {
+                    final players = _unitRoster(controller);
+                    final positions = _orderedPositions(players);
+                    final filtered = _filter(players);
+
+                    return Column(
+                      children: [
+                        _buildHeader(),
+                        _buildUnitTabs(),
+                        _buildSearchRow(),
+                        _buildChipsRow(positions),
+                        const SizedBox(height: 4),
+                        Expanded(
+                          child: _buildBody(controller, filtered),
+                        ),
+                      ],
+                    );
+                  },
                 ),
               ),
-            ),
-            Positioned.fill(
-              child: Container(color: _kSheetBgSurface),
-            ),
-            SafeArea(
-              child: Consumer<TeamCenterController>(
-                builder: (context, controller, _) {
-                  final players = _unitRoster(controller);
-                  final positions = _orderedPositions(players);
-                  final filtered = _filter(players);
-
-                  return Column(
-                    children: [
-                      _buildHeader(),
-                      _buildUnitTabs(),
-                      _buildSearchRow(),
-                      _buildChipsRow(positions),
-                      const SizedBox(height: 4),
-                      Expanded(
-                        child: _buildBody(controller, filtered),
-                      ),
-                    ],
-                  );
-                },
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -141,8 +135,8 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
   Widget _buildHeader() {
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 18, 16, 14),
-      decoration: const BoxDecoration(
-        border: Border(bottom: BorderSide(color: _kBorderSoft)),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: _p.border)),
       ),
       child: Row(
         children: [
@@ -153,7 +147,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
               shape: BoxShape.circle,
               color: widget.team.primaryColor,
               border: Border.all(
-                color: Colors.white.withValues(alpha: 0.15),
+                color: _p.surfaceMuted,
                 width: 2,
               ),
             ),
@@ -175,14 +169,14 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
             ),
           ),
           const SizedBox(width: 10),
-          const Text(
+          Text(
             'TEAM ROSTER',
             style: TextStyle(
               fontFamily: 'Russo One',
               fontSize: 20,
               fontStyle: FontStyle.italic,
               letterSpacing: 0.8,
-              color: Colors.white,
+              color: _p.textPrimary,
             ),
           ),
           const Spacer(),
@@ -193,13 +187,13 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
               height: 30,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: Colors.white.withValues(alpha: 0.08),
+                color: _p.surfaceMuted,
               ),
               alignment: Alignment.center,
               child: Icon(
                 Icons.close,
                 size: 14,
-                color: Colors.white.withValues(alpha: 0.6),
+                color: _p.textSecondary,
               ),
             ),
           ),
@@ -212,8 +206,8 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
   Widget _buildUnitTabs() {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-      decoration: const BoxDecoration(
-        border: Border(bottom: BorderSide(color: _kBorderSoft)),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: _p.border)),
       ),
       child: Row(
         children: List.generate(_units.length, (i) {
@@ -227,7 +221,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                 decoration: BoxDecoration(
                   border: Border(
                     bottom: BorderSide(
-                      color: active ? _kAccentBadge : Colors.transparent,
+                      color: active ? _kAccent : Colors.transparent,
                       width: 2,
                     ),
                   ),
@@ -239,9 +233,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                     fontSize: 11,
                     fontWeight: FontWeight.w700,
                     letterSpacing: 0.99,
-                    color: active
-                        ? Colors.white
-                        : Colors.white.withValues(alpha: 0.35),
+                    color: active ? _p.textPrimary : _p.textMuted,
                   ),
                 ),
               ),
@@ -259,12 +251,12 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
         decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.06),
+          color: _p.surfaceSubtle,
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
             color: _searchFocus.hasFocus
-                ? _kAccentBadge.withValues(alpha: 0.6)
-                : Colors.white.withValues(alpha: 0.07),
+                ? _kAccent.withValues(alpha: 0.6)
+                : _p.chipBorder,
           ),
         ),
         child: Row(
@@ -272,7 +264,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
             Icon(
               Icons.search,
               size: 16,
-              color: Colors.white.withValues(alpha: 0.3),
+              color: _p.textMuted,
             ),
             const SizedBox(width: 8),
             Expanded(
@@ -280,8 +272,8 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                 controller: _searchCtl,
                 focusNode: _searchFocus,
                 onChanged: (v) => setState(() => _query = v),
-                style: const TextStyle(
-                  color: Colors.white,
+                style: TextStyle(
+                  color: _p.textPrimary,
                   fontSize: 14,
                   fontWeight: FontWeight.w500,
                 ),
@@ -291,7 +283,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                   border: InputBorder.none,
                   hintText: 'Search players, position, college…',
                   hintStyle: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.25),
+                    color: _p.textGhost,
                     fontSize: 14,
                     fontWeight: FontWeight.w500,
                   ),
@@ -310,13 +302,13 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                   height: 18,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: Colors.white.withValues(alpha: 0.15),
+                    color: _p.surfaceMuted,
                   ),
                   alignment: Alignment.center,
                   child: Icon(
                     Icons.close,
                     size: 10,
-                    color: Colors.white.withValues(alpha: 0.6),
+                    color: _p.textSecondary,
                   ),
                 ),
               ),
@@ -329,46 +321,46 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
   // ── CHIPS ────────────────────────────────────────────────────────────────
   Widget _buildChipsRow(List<String> positions) {
     final chips = ['ALL', ...positions];
-    return SizedBox(
-      height: 38,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
-        itemCount: chips.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 6),
-        itemBuilder: (_, i) {
-          final c = chips[i];
-          final active = c == _posFilter;
-          return GestureDetector(
-            onTap: () => setState(() => _posFilter = c),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
-              decoration: BoxDecoration(
-                color: active
-                    ? _kChipActive
-                    : Colors.white.withValues(alpha: 0.05),
-                borderRadius: BorderRadius.circular(999),
-                border: Border.all(
-                  color: active
-                      ? _kChipActive
-                      : Colors.white.withValues(alpha: 0.1),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0, 10, 0, 4),
+      child: SizedBox(
+        height: 30,
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          itemCount: chips.length,
+          separatorBuilder: (_, __) => const SizedBox(width: 6),
+          itemBuilder: (_, i) {
+            final c = chips[i];
+            final active = c == _posFilter;
+            return GestureDetector(
+              onTap: () => setState(() => _posFilter = c),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  color: active ? _kAccent : _p.chipBg,
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(
+                    color: active ? _kAccent : _p.chipBorder,
+                  ),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  c,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.77,
+                    color: active ? Colors.white : _p.textMuted,
+                  ),
                 ),
               ),
-              alignment: Alignment.center,
-              child: Text(
-                c,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: 0.77,
-                  color: active
-                      ? Colors.white
-                      : Colors.white.withValues(alpha: 0.45),
-                ),
-              ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }
@@ -382,7 +374,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
       return Center(
         child: Text(
           'Failed to load roster',
-          style: TextStyle(color: Colors.white.withValues(alpha: 0.45)),
+          style: TextStyle(color: _p.textMuted),
         ),
       );
     }
@@ -398,17 +390,20 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
             delegate: _GroupHeaderDelegate(
               label: _positionLabel(g.position),
               count: g.players.length,
+              bg: _p.stickyBg,
+              labelColor: _p.textMuted,
+              countColor: _p.textGhost,
             ),
           ),
           SliverList.separated(
             itemCount: g.players.length,
             itemBuilder: (_, i) => _buildPlayerRow(g.players[i]),
-            separatorBuilder: (_, __) => const Padding(
-              padding: EdgeInsets.only(left: 72, right: 16),
+            separatorBuilder: (_, __) => Padding(
+              padding: const EdgeInsets.only(left: 72, right: 16),
               child: Divider(
                 height: 1,
                 thickness: 1,
-                color: Color(0x0AFFFFFF),
+                color: _p.separator,
               ),
             ),
           ),
@@ -426,13 +421,13 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
           Icon(
             Icons.search_off,
             size: 40,
-            color: Colors.white.withValues(alpha: 0.15),
+            color: _p.surfaceMuted,
           ),
           const SizedBox(height: 10),
           Text(
             'No players found',
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.4),
+              color: _p.textMuted,
               fontSize: 14,
               fontWeight: FontWeight.w600,
             ),
@@ -441,7 +436,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
           Text(
             'Try a different search or filter',
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.3),
+              color: _p.textMuted,
               fontSize: 12,
             ),
           ),
@@ -468,7 +463,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                   style: TextStyle(
                     fontFamily: 'Russo One',
                     fontSize: 15,
-                    color: Colors.white.withValues(alpha: 0.25),
+                    color: _p.textGhost,
                     letterSpacing: 0.3,
                   ),
                 ),
@@ -485,8 +480,8 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                       p.name,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: Colors.white,
+                      style: TextStyle(
+                        color: _p.textPrimary,
                         fontSize: 14,
                         fontWeight: FontWeight.w700,
                         height: 1.2,
@@ -501,7 +496,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                             vertical: 2,
                           ),
                           decoration: BoxDecoration(
-                            color: _kAccentBadge.withValues(alpha: 0.5),
+                            color: _kAccent.withValues(alpha: 0.5),
                             borderRadius: BorderRadius.circular(4),
                           ),
                           child: Text(
@@ -527,7 +522,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
                         style: TextStyle(
                           fontSize: 10,
                           fontWeight: FontWeight.w500,
-                          color: Colors.white.withValues(alpha: 0.32),
+                          color: _p.textMuted,
                         ),
                       ),
                     ],
@@ -538,7 +533,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
               Icon(
                 Icons.chevron_right,
                 size: 18,
-                color: Colors.white.withValues(alpha: 0.18),
+                color: _p.textGhost,
               ),
             ],
           ),
@@ -556,7 +551,7 @@ class _TeamRosterScreenState extends State<TeamRosterScreen> {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(
-          color: Colors.white.withValues(alpha: 0.12),
+          color: _p.logoRing,
           width: 2,
         ),
       ),
@@ -765,8 +760,17 @@ class _PositionGroup {
 class _GroupHeaderDelegate extends SliverPersistentHeaderDelegate {
   final String label;
   final int count;
+  final Color bg;
+  final Color labelColor;
+  final Color countColor;
 
-  _GroupHeaderDelegate({required this.label, required this.count});
+  _GroupHeaderDelegate({
+    required this.label,
+    required this.count,
+    required this.bg,
+    required this.labelColor,
+    required this.countColor,
+  });
 
   @override
   double get minExtent => 36;
@@ -780,7 +784,7 @@ class _GroupHeaderDelegate extends SliverPersistentHeaderDelegate {
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
         child: Container(
-          color: const Color(0xF80E1410),
+          color: bg,
           padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
           alignment: Alignment.centerLeft,
           child: Row(
@@ -792,7 +796,7 @@ class _GroupHeaderDelegate extends SliverPersistentHeaderDelegate {
                   fontFamily: 'Russo One',
                   fontSize: 11,
                   letterSpacing: 1.1,
-                  color: Colors.white.withValues(alpha: 0.4),
+                  color: labelColor,
                 ),
               ),
               Text(
@@ -801,7 +805,7 @@ class _GroupHeaderDelegate extends SliverPersistentHeaderDelegate {
                   fontSize: 10,
                   fontWeight: FontWeight.w700,
                   letterSpacing: 0.5,
-                  color: Colors.white.withValues(alpha: 0.25),
+                  color: countColor,
                 ),
               ),
             ],
@@ -813,7 +817,11 @@ class _GroupHeaderDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   bool shouldRebuild(covariant _GroupHeaderDelegate oldDelegate) {
-    return oldDelegate.label != label || oldDelegate.count != count;
+    return oldDelegate.label != label ||
+        oldDelegate.count != count ||
+        oldDelegate.bg != bg ||
+        oldDelegate.labelColor != labelColor ||
+        oldDelegate.countColor != countColor;
   }
 }
 
@@ -826,6 +834,28 @@ class _PlayerDetailSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.extension<T4LThemeColors>()!;
+    final isDark = theme.brightness == Brightness.dark;
+
+    final sheetBg = isDark ? const Color(0xFF141E16) : colors.surface;
+    final topBorder = isDark ? const Color(0x14FFFFFF) : colors.border;
+    final dividerColor = isDark ? const Color(0x0DFFFFFF) : colors.border;
+    final keyColor =
+        isDark ? Colors.white.withValues(alpha: 0.28) : colors.textMuted;
+    final valColor =
+        isDark ? Colors.white.withValues(alpha: 0.75) : colors.textSecondary;
+    final ghostColor = isDark
+        ? Colors.white.withValues(alpha: 0.1)
+        : colors.textMuted.withValues(alpha: 0.4);
+    final handleColor = isDark
+        ? Colors.white.withValues(alpha: 0.15)
+        : colors.textMuted.withValues(alpha: 0.5);
+    final subColor =
+        isDark ? Colors.white.withValues(alpha: 0.4) : colors.textSecondary;
+    final avatarRing =
+        isDark ? Colors.white.withValues(alpha: 0.2) : colors.border;
+
     final initials = player.name
         .trim()
         .split(RegExp(r'\s+'))
@@ -847,12 +877,10 @@ class _PlayerDetailSheet extends StatelessWidget {
     bioRows.add(['Team', team.id.toUpperCase()]);
 
     return Container(
-      decoration: const BoxDecoration(
-        color: Color(0xFF141E16),
-        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-        border: Border(
-          top: BorderSide(color: Color(0x14FFFFFF)),
-        ),
+      decoration: BoxDecoration(
+        color: sheetBg,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        border: Border(top: BorderSide(color: topBorder)),
       ),
       child: SafeArea(
         top: false,
@@ -864,7 +892,7 @@ class _PlayerDetailSheet extends StatelessWidget {
               height: 4,
               margin: const EdgeInsets.only(top: 12),
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.15),
+                color: handleColor,
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -877,10 +905,7 @@ class _PlayerDetailSheet extends StatelessWidget {
                     height: 54,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      border: Border.all(
-                        color: Colors.white.withValues(alpha: 0.2),
-                        width: 2,
-                      ),
+                      border: Border.all(color: avatarRing, width: 2),
                     ),
                     child: ClipOval(
                       child: player.imageUrl.isNotEmpty
@@ -905,10 +930,10 @@ class _PlayerDetailSheet extends StatelessWidget {
                           player.name,
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontFamily: 'Russo One',
                             fontSize: 18,
-                            color: Colors.white,
+                            color: colors.textPrimary,
                             letterSpacing: 0.36,
                           ),
                         ),
@@ -928,7 +953,7 @@ class _PlayerDetailSheet extends StatelessWidget {
                           style: TextStyle(
                             fontSize: 12,
                             fontWeight: FontWeight.w500,
-                            color: Colors.white.withValues(alpha: 0.4),
+                            color: subColor,
                           ),
                         ),
                       ],
@@ -942,13 +967,13 @@ class _PlayerDetailSheet extends StatelessWidget {
                     style: TextStyle(
                       fontFamily: 'Russo One',
                       fontSize: 32,
-                      color: Colors.white.withValues(alpha: 0.1),
+                      color: ghostColor,
                     ),
                   ),
                 ],
               ),
             ),
-            const Divider(height: 1, color: Color(0x0DFFFFFF)),
+            Divider(height: 1, color: dividerColor),
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 14, 20, 24),
               child: Column(
@@ -965,7 +990,7 @@ class _PlayerDetailSheet extends StatelessWidget {
                               fontSize: 11,
                               fontWeight: FontWeight.w700,
                               letterSpacing: 0.66,
-                              color: Colors.white.withValues(alpha: 0.28),
+                              color: keyColor,
                             ),
                           ),
                           Flexible(
@@ -977,7 +1002,7 @@ class _PlayerDetailSheet extends StatelessWidget {
                               style: TextStyle(
                                 fontSize: 13,
                                 fontWeight: FontWeight.w600,
-                                color: Colors.white.withValues(alpha: 0.75),
+                                color: valColor,
                               ),
                             ),
                           ),
@@ -985,7 +1010,7 @@ class _PlayerDetailSheet extends StatelessWidget {
                       ),
                     ),
                     if (i < bioRows.length - 1)
-                      const Divider(height: 1, color: Color(0x0DFFFFFF)),
+                      Divider(height: 1, color: dividerColor),
                   ],
                 ],
               ),
@@ -1008,6 +1033,78 @@ class _PlayerDetailSheet extends StatelessWidget {
           color: Colors.white,
         ),
       ),
+    );
+  }
+}
+
+// ─── PALETTE (theme-aware surface/text/border resolution) ────────────────
+class _RosterPalette {
+  final bool isDark;
+  final Color scrim;
+  final Color stickyBg;
+  final Color border;
+  final Color separator;
+  final Color textPrimary;
+  final Color textSecondary;
+  final Color textMuted;
+  final Color textGhost;
+  final Color surfaceMuted;
+  final Color surfaceSubtle;
+  final Color chipBg;
+  final Color chipBorder;
+  final Color logoRing;
+
+  const _RosterPalette({
+    required this.isDark,
+    required this.scrim,
+    required this.stickyBg,
+    required this.border,
+    required this.separator,
+    required this.textPrimary,
+    required this.textSecondary,
+    required this.textMuted,
+    required this.textGhost,
+    required this.surfaceMuted,
+    required this.surfaceSubtle,
+    required this.chipBg,
+    required this.chipBorder,
+    required this.logoRing,
+  });
+
+  factory _RosterPalette.from(T4LThemeColors c, bool isDark) {
+    if (isDark) {
+      return _RosterPalette(
+        isDark: true,
+        scrim: Colors.black.withValues(alpha: 0.45),
+        stickyBg: Colors.black.withValues(alpha: 0.55),
+        border: const Color(0x14FFFFFF),
+        separator: const Color(0x0AFFFFFF),
+        textPrimary: Colors.white,
+        textSecondary: Colors.white.withValues(alpha: 0.6),
+        textMuted: Colors.white.withValues(alpha: 0.4),
+        textGhost: Colors.white.withValues(alpha: 0.22),
+        surfaceMuted: Colors.white.withValues(alpha: 0.1),
+        surfaceSubtle: Colors.white.withValues(alpha: 0.06),
+        chipBg: Colors.white.withValues(alpha: 0.07),
+        chipBorder: Colors.white.withValues(alpha: 0.12),
+        logoRing: Colors.white.withValues(alpha: 0.15),
+      );
+    }
+    return _RosterPalette(
+      isDark: false,
+      scrim: Colors.white.withValues(alpha: 0.55),
+      stickyBg: Colors.white.withValues(alpha: 0.7),
+      border: c.border,
+      separator: c.border.withValues(alpha: 0.5),
+      textPrimary: c.textPrimary,
+      textSecondary: c.textSecondary,
+      textMuted: c.textMuted,
+      textGhost: c.textMuted.withValues(alpha: 0.55),
+      surfaceMuted: c.textPrimary.withValues(alpha: 0.06),
+      surfaceSubtle: c.textPrimary.withValues(alpha: 0.04),
+      chipBg: Colors.white.withValues(alpha: 0.6),
+      chipBorder: c.border,
+      logoRing: c.textPrimary.withValues(alpha: 0.12),
     );
   }
 }

--- a/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
+++ b/flutter_app/lib/micro_apps/breaking_news/views/breaking_news_detail_screen.dart
@@ -215,7 +215,6 @@ class _BreakingNewsDetailScreenState extends State<BreakingNewsDetailScreen> {
       ),
     );
   }
-
 }
 
 // ─── Hero ────────────────────────────────────────────────────────────

--- a/flutter_app/lib/micro_apps/radio/controllers/radio_controller.dart
+++ b/flutter_app/lib/micro_apps/radio/controllers/radio_controller.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:audio_service/audio_service.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:tackle4loss_mobile/core/services/audio_player_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';

--- a/flutter_app/lib/micro_apps/radio/views/widgets/radio_home_widget.dart
+++ b/flutter_app/lib/micro_apps/radio/views/widgets/radio_home_widget.dart
@@ -67,6 +67,7 @@ class _RadioHomeWidgetState extends State<RadioHomeWidget>
     if (!mounted || !_scrollController.hasClients) return;
 
     final maxScroll = _scrollController.position.maxScrollExtent;
+    // ignore: deprecated_member_use
     final tickerEnabled = TickerMode.of(context);
     final shouldRun = tickerEnabled && maxScroll > 0;
 

--- a/flutter_app/test/micro_apps/radio/controllers/radio_controller_test.dart
+++ b/flutter_app/test/micro_apps/radio/controllers/radio_controller_test.dart
@@ -29,8 +29,8 @@ class MockAudioPlayerService extends AudioPlayerService {
 class MockHttpClient extends Mock implements http.Client {}
 
 class TestRadioController extends RadioController {
-  TestRadioController(this.tracks, {AudioPlayerService? audioService})
-      : super(languageCode: 'en', audioService: audioService);
+  TestRadioController(this.tracks, {super.audioService})
+      : super(languageCode: 'en');
 
   final List<Map<String, String>> tracks;
 


### PR DESCRIPTION
## Summary
Implements the Claude Design handoff for the Team Roster sheet (`Roster.html`). Independent of PR #82 (Team Center overlay) — this branch is off `main`.

- Italic Russo One header + team-color logo badge + close pill.
- **Offense / Defense / Special** unit tabs with brand-green underline; switching resets filters.
- **Search bar** filters by name, position, or college.
- **Position chips** scrollable horizontally, derived from the unit's actual positions and ordered (QB→TE→OL→DE→DT→LB→DB→ST).
- **Sticky position group headers** with Russo One label + ghost count.
- **Compact player rows**: jersey number, ringed avatar (real headshot with position-tinted fallback), name, position badge, `experience · college` meta line, chevron.
- **Player detail bottom sheet**: handle, large avatar, ghost #jersey numeral, bio rows for fields the model actually has.
- Status/starter/season-stat surface area intentionally dropped — those fields don't exist on `RosterPlayer`, matching how the design itself stripped placeholder stats.

## Test plan
- [ ] `flutter analyze --fatal-warnings lib/core/team_center` (clean locally)
- [ ] `dart format --set-exit-if-changed lib/core/team_center` (clean locally)
- [ ] Open Team Roster from Team Center for several teams; verify each unit loads
- [ ] Search by name fragment, position code (e.g. "CB"), and college; verify clear button
- [ ] Tap each position chip; verify filter resets when switching units
- [ ] Scroll long list; verify position group headers pin and rotate correctly
- [ ] Tap a player; verify detail sheet shows correct image + bio rows
- [ ] iOS + Android visual QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)