### PR TITLE
fix(flutter): guard team center precache against empty image URLs

### DIFF
--- a/flutter_app/lib/core/team_center/views/team_center_overlay.dart
+++ b/flutter_app/lib/core/team_center/views/team_center_overlay.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import '../../models/team_model.dart';
 import '../controllers/team_center_controller.dart';
 import 'widgets/daily_update_card.dart';
@@ -76,7 +77,13 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
     if (_controller.defenseRoster.isNotEmpty) {
       if (!mounted) return;
       for (final player in _controller.defenseRoster) {
-        precacheImage(NetworkImage(player.imageUrl), context);
+        // Skip empty/invalid URLs — `NetworkImage("")` resolves to `file:///`
+        // and throws "No host specified in URI" inside precache.
+        final url = player.imageUrl;
+        if (url.isEmpty) continue;
+        final uri = Uri.tryParse(url);
+        if (uri == null || !uri.hasAuthority) continue;
+        precacheImage(CachedNetworkImageProvider(url), context);
       }
       // Remove listener to run only once (or keep if roster can update)
       _controller.removeListener(_preloadDefenseImages);


### PR DESCRIPTION
## Summary
\`_preloadDefenseImages\` was calling \`precacheImage(NetworkImage(\"\"))\` for any defense-roster player whose \`imageUrl\` is empty. Flutter resolves \`\"\"\` to \`file:///\`, which throws \`Invalid argument(s): No host specified in URI file:///\` inside \`_HttpClient._openUrl\` as soon as precache kicks off (visible in the user's runtime stack trace).

Skip empty and non-network URLs, and route through \`CachedNetworkImageProvider\` so this preload shares the same image cache the depth chart, roster, and injury report surfaces already use.

## Test plan
- [ ] \`flutter analyze --fatal-warnings\` (clean locally)
- [ ] \`dart format --set-exit-if-changed\` (clean locally)
- [ ] Open Team Center for a team whose defense roster has at least one player with an empty image URL — verify no exception is thrown
- [ ] Open Team Center for a team with full headshots — verify defense headshots still warm the cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)