### PR TITLE
feat(flutter): source team daily update from home articles feed

### DIFF
--- a/flutter_app/lib/core/services/articles_service.dart
+++ b/flutter_app/lib/core/services/articles_service.dart
@@ -88,6 +88,30 @@ class ArticlesService {
     return ArticlesPage(items: items, nextCursor: nextCursor);
   }
 
+  /// Returns the most recent article belonging to [teamId] from the home
+  /// articles feed. Scans up to [scanLimit] articles (one page) and returns
+  /// the first match by `team` field, lower-cased on both sides.
+  ///
+  /// Returns `null` if no article in the latest page matches.
+  Future<NewsFeedItem?> fetchLatestArticleForTeam({
+    required String teamId,
+    required String language,
+    int scanLimit = 50,
+  }) async {
+    final target = teamId.toLowerCase();
+    final page = await fetchArticles(language: language, limit: scanLimit);
+    for (final item in page.items) {
+      final teams = item.teams ?? const [];
+      for (final t in teams) {
+        if (t is Map &&
+            (t['team_id']?.toString().toLowerCase() ?? '') == target) {
+          return item;
+        }
+      }
+    }
+    return null;
+  }
+
   Future<BreakingNewsArticle> fetchArticleDetail(
     String id, {
     String? language,

--- a/flutter_app/lib/core/team_center/controllers/team_center_controller.dart
+++ b/flutter_app/lib/core/team_center/controllers/team_center_controller.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../../../micro_apps/standings/services/standings_service.dart';
 import '../../../micro_apps/standings/models/game_model.dart';
+import '../../models/news_feed_item.dart';
 import '../../models/team_model.dart';
+import '../../services/articles_service.dart';
 import '../../services/audio_player_service.dart';
 
 import '../models/team_article.dart';
@@ -15,12 +17,17 @@ import '../models/injury_player.dart';
 class TeamCenterController extends ChangeNotifier {
   final StandingsService _standingsService = StandingsService();
   final AudioPlayerService _audioService = AudioPlayerService();
+  final ArticlesService _articlesService;
+
+  TeamCenterController({ArticlesService? articlesService})
+      : _articlesService = articlesService ?? ArticlesService();
 
   bool _isLoading = false;
   String? _error;
   Game? _lastGame;
   Game? _nextGame;
   TeamArticle? _todaysArticle;
+  NewsFeedItem? _todaysFeedItem;
 
   /// All games for the team in chronological order
   List<Game> _allTeamGames = [];
@@ -33,6 +40,13 @@ class TeamCenterController extends ChangeNotifier {
   Game? get lastGame => _lastGame;
   Game? get nextGame => _nextGame;
   TeamArticle? get todaysArticle => _todaysArticle;
+
+  /// Underlying news feed item for today's article — used to navigate into
+  /// the same detail screen the home news feed pushes (the home articles
+  /// project owns the detail fetcher), rather than the legacy
+  /// `get-team-article-detail` flow.
+  NewsFeedItem? get todaysFeedItem => _todaysFeedItem;
+
   List<Game> get allTeamGames => _allTeamGames;
   int get startIndex => _startIndex;
 
@@ -56,6 +70,7 @@ class TeamCenterController extends ChangeNotifier {
     _isLoading = true;
     _error = null;
     _todaysArticle = null;
+    _todaysFeedItem = null;
     notifyListeners();
 
     try {
@@ -106,19 +121,17 @@ class TeamCenterController extends ChangeNotifier {
 
   Future<void> _loadDailyUpdate(String teamId, String languageCode) async {
     try {
-      final response = await Supabase.instance.client.functions.invoke(
-        'get-team-daily-update',
-        // Ensure team_id is uppercase to match team_abbr (e.g., DEN, BUF)
-        body: {'team_id': teamId.toUpperCase(), 'language_code': languageCode},
+      final feedItem = await _articlesService.fetchLatestArticleForTeam(
+        teamId: teamId,
+        language: languageCode,
       );
 
-      final data = response.data;
-      if (data != null && data['article'] != null) {
-        _todaysArticle = TeamArticle.fromJson(data['article']);
-      }
+      _todaysFeedItem = feedItem;
+      _todaysArticle = feedItem != null ? _toTeamArticle(feedItem) : null;
     } catch (e) {
       debugPrint('Failed to load daily update: $e');
-      // Set fallback even on error to stop spinner
+      _todaysFeedItem = null;
+      // Surface a placeholder so the card stops the spinner state.
       _todaysArticle = TeamArticle(
         id: 'placeholder_error',
         title: 'Stay tuned for updates!',
@@ -127,6 +140,21 @@ class TeamCenterController extends ChangeNotifier {
         publishedAt: DateTime.now(),
       );
     }
+  }
+
+  /// Map a home-feed [NewsFeedItem] onto the [TeamArticle] shape consumed by
+  /// the existing Daily Update card. The home feed has no per-article TTS
+  /// audio file, so [TeamArticle.audioUrl] stays null and the play button on
+  /// the card is inert (matching how the card already short-circuits on a
+  /// missing audio URL).
+  TeamArticle _toTeamArticle(NewsFeedItem item) {
+    return TeamArticle(
+      id: item.id,
+      title: item.headline ?? item.xPost,
+      summary: item.xPost,
+      imageUrl: item.imageUrl ?? '',
+      publishedAt: item.createdAt,
+    );
   }
 
   List<RosterPlayer> _offenseRoster = [];

--- a/flutter_app/lib/core/team_center/views/team_center_overlay.dart
+++ b/flutter_app/lib/core/team_center/views/team_center_overlay.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import '../../models/team_model.dart';
 import '../controllers/team_center_controller.dart';
 import 'widgets/daily_update_card.dart';
@@ -76,7 +77,13 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
     if (_controller.defenseRoster.isNotEmpty) {
       if (!mounted) return;
       for (final player in _controller.defenseRoster) {
-        precacheImage(NetworkImage(player.imageUrl), context);
+        // Skip empty/invalid URLs — `NetworkImage("")` resolves to `file:///`
+        // and throws "No host specified in URI" inside precache.
+        final url = player.imageUrl;
+        if (url.isEmpty) continue;
+        final uri = Uri.tryParse(url);
+        if (uri == null || !uri.hasAuthority) continue;
+        precacheImage(CachedNetworkImageProvider(url), context);
       }
       // Remove listener to run only once (or keep if roster can update)
       _controller.removeListener(_preloadDefenseImages);

--- a/flutter_app/lib/core/team_center/views/team_center_overlay.dart
+++ b/flutter_app/lib/core/team_center/views/team_center_overlay.dart
@@ -7,10 +7,10 @@ import 'widgets/daily_update_card.dart';
 import 'widgets/game_carousel.dart';
 import 'widgets/team_menu_button.dart';
 import '../../os_shell/widgets/mini_player.dart';
+import '../../os_shell/widgets/news_feed/feed_navigation.dart';
 import 'team_roster_screen.dart';
 import 'team_depth_chart_screen.dart';
 import 'team_injury_report_screen.dart';
-import 'team_article_screen.dart';
 
 /// Overlay widget that displays the Team Center dashboard.
 class TeamCenterOverlay extends StatefulWidget {
@@ -122,36 +122,19 @@ class _TeamCenterOverlayState extends State<TeamCenterOverlay> {
                             children: [
                               const SizedBox(height: 10),
 
-                              // Daily Update
+                              // Daily Update — sourced from the home
+                              // articles project, filtered by team. Tapping
+                              // the card opens the same detail screen the
+                              // home news feed pushes (so the article comes
+                              // from the same backend in both places).
                               DailyUpdateCard(
                                 article: controller.todaysArticle,
                                 teamColor: widget.team.primaryColor,
                                 onTap: () => controller.playArticleAudio(),
                                 onImageTap: () {
-                                  if (controller.todaysArticle != null) {
-                                    Navigator.of(context).push(
-                                      PageRouteBuilder(
-                                        opaque:
-                                            false, // Keep previous route visible
-                                        pageBuilder: (context, animation,
-                                                secondaryAnimation) =>
-                                            TeamArticleScreen(
-                                          articleId:
-                                              controller.todaysArticle!.id,
-                                          languageCode: widget.languageCode,
-                                          initialArticle:
-                                              controller.todaysArticle,
-                                        ),
-                                        transitionsBuilder: (context, animation,
-                                            secondaryAnimation, child) {
-                                          return FadeTransition(
-                                            opacity: animation,
-                                            child: child,
-                                          );
-                                        },
-                                      ),
-                                    );
-                                  }
+                                  final feedItem = controller.todaysFeedItem;
+                                  if (feedItem == null) return;
+                                  openNewsItemDetail(context, feedItem);
                                 },
                               ),
 


### PR DESCRIPTION
## Summary
The Team Center's Daily Update card was loading from the legacy \`get-team-daily-update\` edge function on the main Supabase project, while the home news feed pulls from a separate articles project. The two surfaces could disagree on what counts as \"today's story\" for a team. Route the Daily Update through the home articles project so it's the same article in both places, just filtered by team.

- Add \`ArticlesService.fetchLatestArticleForTeam(teamId, language, {scanLimit})\` — scans one page of \`get-articles\` and returns the first \`NewsFeedItem\` whose \`team\` matches (case-insensitive).
- \`TeamCenterController._loadDailyUpdate\` calls the helper, maps the matched \`NewsFeedItem\` onto the existing \`TeamArticle\` shape the card consumes, and exposes the underlying feed item so the overlay can navigate via the home \`openNewsItemDetail\` flow.
- The Daily Update card's tap now opens \`BreakingNewsDetailScreen\` via \`openNewsItemDetail\`, so the detail fetcher is the home articles project too.
- Home articles have no per-article TTS audio, so \`audioUrl\` stays null and the play button stays inert (matches the card's existing early-return on missing audio).

## Test plan
- [ ] \`flutter analyze --fatal-warnings\` (clean locally)
- [ ] \`dart format --set-exit-if-changed lib/core/services lib/core/team_center\` (clean locally)
- [ ] \`flutter test\` (218 tests pass locally)
- [ ] Open Team Center for a team that has recent articles on the home feed — verify the Daily Update card shows the same headline/image as the matching home feed entry
- [ ] Open Team Center for a team with no recent articles in the latest page — verify the card stays in its placeholder/empty state without throwing
- [ ] Tap the card — verify it pushes \`BreakingNewsDetailScreen\` (same as the home news feed), not the legacy \`TeamArticleScreen\`
- [ ] iOS + Android visual QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)